### PR TITLE
Enhance history

### DIFF
--- a/src/edit/buffer.rs
+++ b/src/edit/buffer.rs
@@ -5,7 +5,7 @@ use crate::{
     grapheme::{Grapheme, Graphemes},
 };
 
-/// New type of editor to store the user inputs.
+/// Store the user inputs.
 #[derive(Debug, Clone, Default)]
 pub struct Buffer(Editor<Graphemes>);
 

--- a/src/edit/history.rs
+++ b/src/edit/history.rs
@@ -6,7 +6,7 @@ use crate::{
     grapheme::Graphemes,
 };
 
-/// New type of editor to store the histroy of the user inputs.
+/// Store the histroy of the past user inputs.
 #[derive(Debug, Clone)]
 pub struct History {
     editor: Editor<Vec<Graphemes>>,

--- a/src/edit/selectbox.rs
+++ b/src/edit/selectbox.rs
@@ -5,7 +5,7 @@ use crate::{
     grapheme::Graphemes,
 };
 
-/// New type of editor to store the candidates to choose the items from.
+/// Store the candidates to choose the items from.
 #[derive(Debug, Clone, Default)]
 pub struct SelectBox(Editor<Vec<Graphemes>>);
 


### PR DESCRIPTION
- Define `limit_len` which means how many the past user inputs are stored in history.
- (Some docstrings in `edit` modules were fixed)