### PR TITLE
v0.4.7 Loop for readline

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Put the package in your `Cargo.toml`.
 
 ```toml
 [dependencies]
-promkit = "0.4.6"
+promkit = "0.4.7"
 ```
 
 ## Features

--- a/promkit/Cargo.toml
+++ b/promkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "promkit"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["ynqa <un.pensiero.vano@gmail.com>"]
 edition = "2021"
 description = "A toolkit for building your own interactive command-line tools"

--- a/promkit/examples/readline_loop.rs
+++ b/promkit/examples/readline_loop.rs
@@ -1,0 +1,18 @@
+use promkit::preset::readline::Readline;
+
+fn main() -> anyhow::Result<()> {
+    let mut p = Readline::default().prompt()?;
+
+    loop {
+        match p.run() {
+            Ok(cmd) => {
+                println!("result: {:?}", cmd);
+            }
+            Err(_) => {
+                println!("Bye!");
+                break;
+            }
+        }
+    }
+    Ok(())
+}

--- a/promkit/src/lib.rs
+++ b/promkit/src/lib.rs
@@ -174,7 +174,7 @@ pub trait Finalizer {
     ///
     /// Returns a `Result` containing the final result of the prompt. The type of the result
     /// is defined by the `Return` associated type.
-    fn finalize(&self) -> anyhow::Result<Self::Return>;
+    fn finalize(&mut self) -> anyhow::Result<Self::Return>;
 }
 
 /// A trait for rendering components within a prompt.

--- a/promkit/src/lib.rs
+++ b/promkit/src/lib.rs
@@ -270,6 +270,9 @@ impl<T: Renderer> Prompt<T> {
                 }
                 _ => {
                     if self.renderer.evaluate(&ev)? == PromptSignal::Quit {
+                        // Renderer has a possibility to disable the cursor color to indicate termination,
+                        // and so ensure to display the state of Renderer at the end.
+                        terminal.draw(&self.renderer.create_panes(size.0, size.1))?;
                         break;
                     }
                 }

--- a/promkit/src/lib.rs
+++ b/promkit/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! promkit = "0.4.6"
+//! promkit = "0.4.7"
 //! ```
 //!
 //! ## Features
@@ -19,13 +19,13 @@
 //! - Support cross-platform both UNIX and Windows owing to [crossterm](https://github.com/crossterm-rs/crossterm)
 //! - Various building methods
 //!   - Preset; Support for quickly setting up a UI by providing simple parameters.
-//!     - [Readline](https://github.com/ynqa/promkit/tree/v0.4.6#readline)
-//!     - [Confirm](https://github.com/ynqa/promkit/tree/v0.4.6#confirm)
-//!     - [Password](https://github.com/ynqa/promkit/tree/v0.4.6#password)
-//!     - [Select](https://github.com/ynqa/promkit/tree/v0.4.6#select)
-//!     - [QuerySelect](https://github.com/ynqa/promkit/tree/v0.4.6#queryselect)
-//!     - [Checkbox](https://github.com/ynqa/promkit/tree/v0.4.6#checkbox)
-//!     - [Tree](https://github.com/ynqa/promkit/tree/v0.4.6#tree)
+//!     - [Readline](https://github.com/ynqa/promkit/tree/v0.4.7#readline)
+//!     - [Confirm](https://github.com/ynqa/promkit/tree/v0.4.7#confirm)
+//!     - [Password](https://github.com/ynqa/promkit/tree/v0.4.7#password)
+//!     - [Select](https://github.com/ynqa/promkit/tree/v0.4.7#select)
+//!     - [QuerySelect](https://github.com/ynqa/promkit/tree/v0.4.7#queryselect)
+//!     - [Checkbox](https://github.com/ynqa/promkit/tree/v0.4.7#checkbox)
+//!     - [Tree](https://github.com/ynqa/promkit/tree/v0.4.7#tree)
 //!   - Combining various UI components.
 //!     - They are provided with the same interface, allowing users to choose and
 //!       assemble them according to their preferences.
@@ -39,7 +39,7 @@
 //!
 //! ## Examples/Demos
 //!
-//! See [here](https://github.com/ynqa/promkit/tree/v0.4.6#examplesdemos)
+//! See [here](https://github.com/ynqa/promkit/tree/v0.4.7#examplesdemos)
 //!
 //! ## Why *promkit*?
 //!

--- a/promkit/src/preset/checkbox/render.rs
+++ b/promkit/src/preset/checkbox/render.rs
@@ -23,7 +23,7 @@ pub struct Renderer {
 impl crate::Finalizer for Renderer {
     type Return = Vec<String>;
 
-    fn finalize(&self) -> anyhow::Result<Self::Return> {
+    fn finalize(&mut self) -> anyhow::Result<Self::Return> {
         Ok(self
             .checkbox_snapshot
             .after()

--- a/promkit/src/preset/form/render.rs
+++ b/promkit/src/preset/form/render.rs
@@ -35,7 +35,7 @@ pub struct Renderer {
 impl crate::Finalizer for Renderer {
     type Return = Vec<String>;
 
-    fn finalize(&self) -> anyhow::Result<Self::Return> {
+    fn finalize(&mut self) -> anyhow::Result<Self::Return> {
         Ok(self
             .text_editor_states
             .contents()

--- a/promkit/src/preset/json/render.rs
+++ b/promkit/src/preset/json/render.rs
@@ -26,7 +26,7 @@ pub struct Renderer {
 impl crate::Finalizer for Renderer {
     type Return = (JsonNode, Option<JsonPath>);
 
-    fn finalize(&self) -> anyhow::Result<Self::Return> {
+    fn finalize(&mut self) -> anyhow::Result<Self::Return> {
         Ok(self
             .json_snapshot
             .after()

--- a/promkit/src/preset/listbox/render.rs
+++ b/promkit/src/preset/listbox/render.rs
@@ -16,7 +16,7 @@ pub struct Renderer {
 impl crate::Finalizer for Renderer {
     type Return = String;
 
-    fn finalize(&self) -> anyhow::Result<Self::Return> {
+    fn finalize(&mut self) -> anyhow::Result<Self::Return> {
         Ok(self.listbox_snapshot.after().listbox.get().to_string())
     }
 }

--- a/promkit/src/preset/query_selector/render.rs
+++ b/promkit/src/preset/query_selector/render.rs
@@ -33,7 +33,7 @@ pub struct Renderer {
 impl crate::Finalizer for Renderer {
     type Return = String;
 
-    fn finalize(&self) -> anyhow::Result<Self::Return> {
+    fn finalize(&mut self) -> anyhow::Result<Self::Return> {
         Ok(self.listbox_snapshot.after().listbox.get().to_string())
     }
 }

--- a/promkit/src/preset/readline/keymap.rs
+++ b/promkit/src/preset/readline/keymap.rs
@@ -1,3 +1,5 @@
+use crossterm::style::ContentStyle;
+
 use crate::{
     crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers},
     listbox::Listbox,
@@ -63,6 +65,9 @@ pub fn default(
                     if let Some(ref mut history) = &mut text_editor_after_mut.history {
                         history.insert(text);
                     }
+                    // For representing the end of the prompt,
+                    // reset the style of the cursor to default.
+                    text_editor_after_mut.active_char_style = ContentStyle::default();
                     Ok(PromptSignal::Quit)
                 } else {
                     Ok(PromptSignal::Continue)

--- a/promkit/src/preset/readline/render.rs
+++ b/promkit/src/preset/readline/render.rs
@@ -30,13 +30,15 @@ pub struct Renderer {
 impl crate::Finalizer for Renderer {
     type Return = String;
 
-    fn finalize(&self) -> anyhow::Result<Self::Return> {
-        Ok(self
+    fn finalize(&mut self) -> anyhow::Result<Self::Return> {
+        let ret = self
             .text_editor_snapshot
             .after()
             .texteditor
             .text_without_cursor()
-            .to_string())
+            .to_string();
+        self.text_editor_snapshot.reset_after_to_init();
+        Ok(ret)
     }
 }
 

--- a/promkit/src/preset/tree/render.rs
+++ b/promkit/src/preset/tree/render.rs
@@ -21,7 +21,7 @@ pub struct Renderer {
 impl crate::Finalizer for Renderer {
     type Return = Vec<String>;
 
-    fn finalize(&self) -> anyhow::Result<Self::Return> {
+    fn finalize(&mut self) -> anyhow::Result<Self::Return> {
         Ok(self.tree_snapshot.after().tree.get())
     }
 }


### PR DESCRIPTION
- Bump up version to v0.4.7
- Adjust something to run readline in a loop.
- Add an example for loop of readline (until `ctrl+c`)