### PR TITLE
Fix history reset at readline renderer finilization

### DIFF
--- a/promkit/src/preset/readline/render.rs
+++ b/promkit/src/preset/readline/render.rs
@@ -37,7 +37,12 @@ impl crate::Finalizer for Renderer {
             .texteditor
             .text_without_cursor()
             .to_string();
+
+        // Keep history over state reset
+        let history = self.text_editor_snapshot.after_mut().history.take();
         self.text_editor_snapshot.reset_after_to_init();
+        self.text_editor_snapshot.after_mut().history = history;
+
         Ok(ret)
     }
 }


### PR DESCRIPTION
Fixes #40 

Now `reset_after_to_init` clear history at readline renderer's `finalize`.
So this PR add save and restore logic for history to fix it.