### PR TITLE
Fix broken format after calling run

### DIFF
--- a/promkit/src/lib.rs
+++ b/promkit/src/lib.rs
@@ -283,6 +283,7 @@ impl<T: Renderer> Prompt<T> {
             terminal.draw(&self.renderer.create_panes(size.0, size.1))?;
         }
 
+        disable_raw_mode()?;
         self.renderer.finalize()
     }
 }


### PR DESCRIPTION
Fixes #50 

Console can't be controlled normally after calling `run` because raw console mode is kept.
To fix it, this PR disables raw mode before finishing `run`.