### PR TITLE
Revert "Add custom writer"

### DIFF
--- a/promkit/src/preset/checkbox.rs
+++ b/promkit/src/preset/checkbox.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, fmt::Display, io};
+use std::{cell::RefCell, fmt::Display};
 
 use crate::{
     checkbox,
@@ -20,8 +20,6 @@ pub struct Checkbox {
     title_state: text::State,
     /// State for the checkbox list itself.
     checkbox_state: checkbox::State,
-    /// Writer to which promptkit write its contents
-    writer: Box<dyn io::Write>,
 }
 
 impl Checkbox {
@@ -51,7 +49,6 @@ impl Checkbox {
                 lines: Default::default(),
             },
             keymap: ActiveKeySwitcher::new("default", self::keymap::default),
-            writer: Box::new(io::stdout()),
         }
     }
 
@@ -74,7 +71,6 @@ impl Checkbox {
                 lines: Default::default(),
             },
             keymap: ActiveKeySwitcher::new("default", self::keymap::default),
-            writer: Box::new(io::stdout()),
         }
     }
 
@@ -125,12 +121,6 @@ impl Checkbox {
         self
     }
 
-    /// Sets writer.
-    pub fn writer<W: io::Write + 'static>(mut self, writer: W) -> Self {
-        self.writer = Box::new(writer);
-        self
-    }
-
     /// Displays the checkbox prompt and waits for user input.
     /// Returns a `Result` containing the `Prompt` result,
     /// which is a list of selected options.
@@ -141,7 +131,6 @@ impl Checkbox {
                 title_state: self.title_state,
                 checkbox_state: self.checkbox_state,
             },
-            writer: self.writer,
         })
     }
 }

--- a/promkit/src/preset/form.rs
+++ b/promkit/src/preset/form.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, io};
+use std::cell::RefCell;
 
 use crate::{
     core::Cursor,
@@ -17,8 +17,6 @@ pub struct Form {
     text_editor_states: Vec<text_editor::State>,
     /// Overwrite the default styles of text editor states when unselected.
     overwrite_styles: Vec<render::Style>,
-    /// Writer to which promptkit write its contents
-    writer: Box<dyn io::Write>,
 }
 
 impl Form {
@@ -44,14 +42,7 @@ impl Form {
             keymap: ActiveKeySwitcher::new("default", self::keymap::default as keymap::Keymap),
             text_editor_states,
             overwrite_styles,
-            writer: Box::new(io::stdout()),
         }
-    }
-
-    /// Sets writer.
-    pub fn writer<W: io::Write + 'static>(mut self, writer: W) -> Self {
-        self.writer = Box::new(writer);
-        self
     }
 
     pub fn prompt(self) -> anyhow::Result<Prompt<render::Renderer>> {
@@ -71,9 +62,6 @@ impl Form {
             overwrite_styles: self.overwrite_styles,
         };
         renderer.overwrite_styles();
-        Ok(Prompt {
-            renderer,
-            writer: self.writer,
-        })
+        Ok(Prompt { renderer })
     }
 }

--- a/promkit/src/preset/json.rs
+++ b/promkit/src/preset/json.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, io};
+use std::cell::RefCell;
 
 use crate::{
     crossterm::style::{Attribute, Attributes, Color, ContentStyle},
@@ -18,8 +18,6 @@ pub struct Json {
     keymap: ActiveKeySwitcher<keymap::Keymap>,
     title_state: text::State,
     json_state: jsonstream::State,
-    /// Writer to which promptkit write its contents
-    writer: Box<dyn io::Write>,
 }
 
 impl Json {
@@ -53,7 +51,6 @@ impl Json {
                 lines: Default::default(),
             },
             keymap: ActiveKeySwitcher::new("default", self::keymap::default),
-            writer: Box::new(io::stdout()),
         }
     }
 
@@ -98,12 +95,6 @@ impl Json {
         self
     }
 
-    /// Sets writer.
-    pub fn writer<W: io::Write + 'static>(mut self, writer: W) -> Self {
-        self.writer = Box::new(writer);
-        self
-    }
-
     /// Creates a prompt based on the current configuration of the `Json` instance.
     pub fn prompt(self) -> anyhow::Result<Prompt<render::Renderer>> {
         Ok(Prompt {
@@ -112,7 +103,6 @@ impl Json {
                 title_state: self.title_state,
                 json_state: self.json_state,
             },
-            writer: self.writer,
         })
     }
 }

--- a/promkit/src/preset/listbox.rs
+++ b/promkit/src/preset/listbox.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, fmt::Display, io};
+use std::{cell::RefCell, fmt::Display};
 
 use crate::{
     crossterm::style::{Attribute, Attributes, Color, ContentStyle},
@@ -19,8 +19,6 @@ pub struct Listbox {
     title_state: text::State,
     /// State for the selectable list itself.
     listbox_state: listbox::State,
-    /// Writer to which promptkit write its contents
-    writer: Box<dyn io::Write>,
 }
 
 impl Listbox {
@@ -48,7 +46,6 @@ impl Listbox {
                 lines: Default::default(),
             },
             keymap: ActiveKeySwitcher::new("default", self::keymap::default),
-            writer: Box::new(io::stdout()),
         }
     }
 
@@ -93,12 +90,6 @@ impl Listbox {
         self
     }
 
-    /// Sets writer.
-    pub fn writer<W: io::Write + 'static>(mut self, writer: W) -> Self {
-        self.writer = Box::new(writer);
-        self
-    }
-
     /// Displays the select prompt and waits for user input.
     /// Returns a `Result` containing the `Prompt` result,
     /// which is the selected option.
@@ -109,7 +100,6 @@ impl Listbox {
                 title_state: self.title_state,
                 listbox_state: self.listbox_state,
             },
-            writer: self.writer,
         })
     }
 }

--- a/promkit/src/preset/query_selector.rs
+++ b/promkit/src/preset/query_selector.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, fmt::Display, io};
+use std::{cell::RefCell, fmt::Display};
 
 use crate::{
     crossterm::style::{Attribute, Attributes, Color, ContentStyle},
@@ -28,8 +28,6 @@ pub struct QuerySelector {
     /// A filter function to apply to the list box items
     /// based on the text editor input.
     filter: render::Filter,
-    /// Writer to which promptkit write its contents
-    writer: Box<dyn io::Write>,
 }
 
 impl QuerySelector {
@@ -77,7 +75,6 @@ impl QuerySelector {
             },
             keymap: ActiveKeySwitcher::new("default", self::keymap::default),
             filter,
-            writer: Box::new(io::stdout()),
         }
     }
 
@@ -158,12 +155,6 @@ impl QuerySelector {
         self
     }
 
-    /// Sets writer.
-    pub fn writer<W: io::Write + 'static>(mut self, writer: W) -> Self {
-        self.writer = Box::new(writer);
-        self
-    }
-
     /// Displays the query select prompt and waits for user input.
     /// Returns a `Result` containing the `Prompt` result,
     /// which is the selected option.
@@ -176,7 +167,6 @@ impl QuerySelector {
                 listbox_snapshot: Snapshot::<listbox::State>::new(self.listbox_state),
                 filter: self.filter,
             },
-            writer: self.writer,
         })
     }
 }

--- a/promkit/src/preset/readline.rs
+++ b/promkit/src/preset/readline.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashSet, io};
+use std::{cell::RefCell, collections::HashSet};
 
 use crate::{
     crossterm::style::{Attribute, Attributes, Color, ContentStyle},
@@ -34,8 +34,6 @@ pub struct Readline {
     validator: Option<ValidatorManager<str>>,
     /// State for displaying error messages based on input validation.
     error_message_state: text::State,
-    /// Writer to which promptkit write its contents
-    writer: Box<dyn io::Write>,
 }
 
 impl Default for Readline {
@@ -84,7 +82,6 @@ impl Default for Readline {
                     .build(),
                 lines: None,
             },
-            writer: Box::new(io::stdout()),
         }
     }
 }
@@ -177,12 +174,6 @@ impl Readline {
         self
     }
 
-    /// Sets writer.
-    pub fn writer<W: io::Write + 'static>(mut self, writer: W) -> Self {
-        self.writer = Box::new(writer);
-        self
-    }
-
     /// Initiates the prompt process,
     /// displaying the configured UI elements and handling user input.
     pub fn prompt(self) -> anyhow::Result<Prompt<render::Renderer>> {
@@ -196,7 +187,6 @@ impl Readline {
                 validator: self.validator,
                 error_message_snapshot: Snapshot::<text::State>::new(self.error_message_state),
             },
-            writer: self.writer,
         })
     }
 }

--- a/promkit/src/preset/text.rs
+++ b/promkit/src/preset/text.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, io};
+use std::cell::RefCell;
 
 use crossterm::style::ContentStyle;
 
@@ -10,8 +10,6 @@ pub mod render;
 pub struct Text {
     keymap: ActiveKeySwitcher<keymap::Keymap>,
     text_state: text::State,
-    /// Writer to which promptkit write its contents
-    writer: Box<dyn io::Write>,
 }
 
 impl Text {
@@ -23,7 +21,6 @@ impl Text {
                 style: Default::default(),
                 lines: None,
             },
-            writer: Box::new(io::stdout()),
         }
     }
 
@@ -38,7 +35,6 @@ impl Text {
                 keymap: RefCell::new(self.keymap),
                 text_state: self.text_state,
             },
-            writer: self.writer,
         })
     }
 }

--- a/promkit/src/preset/tree.rs
+++ b/promkit/src/preset/tree.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, io};
+use std::cell::RefCell;
 
 use crate::{
     crossterm::style::{Attribute, Attributes, Color, ContentStyle},
@@ -20,8 +20,6 @@ pub struct Tree {
     title_state: text::State,
     /// State for the tree itself.
     tree_state: tree::State,
-    /// Writer to which promptkit write its contents
-    writer: Box<dyn io::Write>,
 }
 
 impl Tree {
@@ -49,7 +47,6 @@ impl Tree {
                 lines: Default::default(),
                 indent: 2,
             },
-            writer: Box::new(io::stdout()),
         }
     }
 
@@ -106,12 +103,6 @@ impl Tree {
         self
     }
 
-    /// Sets writer.
-    pub fn writer<W: io::Write + 'static>(mut self, writer: W) -> Self {
-        self.writer = Box::new(writer);
-        self
-    }
-
     /// Displays the tree prompt and waits for user input.
     /// Returns a `Result` containing the `Prompt` result,
     /// which is a list of selected options.
@@ -122,7 +113,6 @@ impl Tree {
                 title_state: self.title_state,
                 tree_state: self.tree_state,
             },
-            writer: self.writer,
         })
     }
 }


### PR DESCRIPTION
Reverts ynqa/promkit#36

---

In Arc<Mutex<Renderer>> in jnv, it is hard to manage the lifetime.
- https://github.com/ynqa/jnv/blob/v0.5.0/src/render.rs

Arc<Mutex<...>> is a structure used to share between multiple threads. If you store a reference (e.g., &mut stdout) inside it, lifetime management becomes very complex. This is especially true when a reference needs to live beyond its scope, which can lead to conflicts with Rust's borrow checker.

The mechanism for injecting `io::Write` from the outside, please allow me to reconsider.