### PR TITLE
docs: Render all features in Rustdocs

### DIFF
--- a/promkit-widgets/src/lib.rs
+++ b/promkit-widgets/src/lib.rs
@@ -1,21 +1,30 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub mod cursor;
 
 #[cfg(feature = "checkbox")]
+#[cfg_attr(docsrs, doc(cfg(feature = "checkbox")))]
 pub mod checkbox;
 
 #[cfg(feature = "jsonstream")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jsonstream")))]
 pub mod jsonstream;
 #[cfg(feature = "jsonstream")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jsonstream")))]
 pub use serde_json;
 
 #[cfg(feature = "listbox")]
+#[cfg_attr(docsrs, doc(cfg(feature = "listbox")))]
 pub mod listbox;
 
 #[cfg(feature = "text")]
+#[cfg_attr(docsrs, doc(cfg(feature = "text")))]
 pub mod text;
 
 #[cfg(feature = "texteditor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "texteditor")))]
 pub mod text_editor;
 
 #[cfg(feature = "tree")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tree")))]
 pub mod tree;

--- a/promkit/Cargo.toml
+++ b/promkit/Cargo.toml
@@ -26,19 +26,10 @@ all = [
     "text",
     "tree",
 ]
-checkbox = [
-    "promkit-widgets/checkbox",
-    "promkit-widgets/text",
-]
+checkbox = ["promkit-widgets/checkbox", "promkit-widgets/text"]
 form = ["promkit-widgets/texteditor"]
-json = [
-    "promkit-widgets/jsonstream",
-    "promkit-widgets/text",
-]
-listbox = [
-    "promkit-widgets/listbox",
-    "promkit-widgets/text",
-]
+json = ["promkit-widgets/jsonstream", "promkit-widgets/text"]
+listbox = ["promkit-widgets/listbox", "promkit-widgets/text"]
 query-selector = [
     "promkit-widgets/listbox",
     "promkit-widgets/text",
@@ -52,13 +43,14 @@ readline = [
 password = ["readline"]
 confirm = ["readline"]
 text = ["promkit-widgets/text"]
-tree = [
-    "promkit-widgets/text",
-    "promkit-widgets/tree",
-]
+tree = ["promkit-widgets/text", "promkit-widgets/tree"]
 
 [dependencies]
-anyhow ={ workspace = true }
+anyhow = { workspace = true }
 promkit-core = { path = "../promkit-core", version = "=0.1.1" }
 promkit-widgets = { path = "../promkit-widgets", version = "=0.1.1" }
 radix_trie = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/promkit/src/lib.rs
+++ b/promkit/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use promkit_core;
 pub use promkit_core::crossterm;

--- a/promkit/src/preset.rs
+++ b/promkit/src/preset.rs
@@ -1,39 +1,39 @@
-/// Provides a checkbox interface for multiple options selection.
 #[cfg(feature = "checkbox")]
+#[cfg_attr(docsrs, doc(cfg(feature = "checkbox")))]
 pub mod checkbox;
 
-/// Offers functionality for reading input from the user.
 #[cfg(feature = "readline")]
+#[cfg_attr(docsrs, doc(cfg(feature = "readline")))]
 pub mod readline;
 
-/// Contains a simple yes/no confirmation prompt.
 #[cfg(feature = "confirm")]
+#[cfg_attr(docsrs, doc(cfg(feature = "confirm")))]
 pub mod confirm;
 
-/// Provides a password input interface with masking and validation.
 #[cfg(feature = "password")]
+#[cfg_attr(docsrs, doc(cfg(feature = "password")))]
 pub mod password;
 
-/// Enables parsing and interaction with JSON data.
 #[cfg(feature = "json")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub mod json;
 
-/// Implements a list box for single or multiple selections from a list.
 #[cfg(feature = "listbox")]
+#[cfg_attr(docsrs, doc(cfg(feature = "listbox")))]
 pub mod listbox;
 
-/// Facilitates querying and selecting from a set of options in a structured format.
 #[cfg(feature = "query-selector")]
+#[cfg_attr(docsrs, doc(cfg(feature = "query-selector")))]
 pub mod query_selector;
 
-/// Supports creating and interacting with a tree structure for hierarchical data.
 #[cfg(feature = "tree")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tree")))]
 pub mod tree;
 
-/// Provides multiple readline input options.
 #[cfg(feature = "form")]
+#[cfg_attr(docsrs, doc(cfg(feature = "form")))]
 pub mod form;
 
-/// Provides a static text display.
 #[cfg(feature = "text")]
+#[cfg_attr(docsrs, doc(cfg(feature = "text")))]
 pub mod text;

--- a/promkit/src/preset/checkbox.rs
+++ b/promkit/src/preset/checkbox.rs
@@ -1,3 +1,5 @@
+//! Provides a checkbox interface for multiple options selection.
+
 use std::{cell::RefCell, fmt::Display};
 
 use promkit_widgets::{

--- a/promkit/src/preset/confirm.rs
+++ b/promkit/src/preset/confirm.rs
@@ -1,3 +1,5 @@
+//! Contains a simple yes/no confirmation prompt.
+
 use crate::Prompt;
 
 use crate::preset::readline::{render, Readline};

--- a/promkit/src/preset/form.rs
+++ b/promkit/src/preset/form.rs
@@ -1,3 +1,5 @@
+//! Provides multiple readline input options.
+
 use std::cell::RefCell;
 
 use promkit_core::crossterm::style::ContentStyle;

--- a/promkit/src/preset/json.rs
+++ b/promkit/src/preset/json.rs
@@ -1,3 +1,5 @@
+//! Enables parsing and interaction with JSON data.
+
 use std::cell::RefCell;
 
 use promkit_widgets::{

--- a/promkit/src/preset/listbox.rs
+++ b/promkit/src/preset/listbox.rs
@@ -1,3 +1,5 @@
+//! Implements a list box for single or multiple selections from a list.
+
 use std::{cell::RefCell, fmt::Display};
 
 use promkit_widgets::{

--- a/promkit/src/preset/password.rs
+++ b/promkit/src/preset/password.rs
@@ -1,3 +1,5 @@
+//! Provides a password input interface with masking and validation.
+
 use crate::{
     crossterm::style::ContentStyle,
     validate::{ErrorMessageGenerator, Validator},

--- a/promkit/src/preset/query_selector.rs
+++ b/promkit/src/preset/query_selector.rs
@@ -1,3 +1,5 @@
+//! Facilitates querying and selecting from a set of options in a structured format.
+
 use std::{cell::RefCell, fmt::Display};
 
 use promkit_widgets::{

--- a/promkit/src/preset/readline.rs
+++ b/promkit/src/preset/readline.rs
@@ -1,3 +1,5 @@
+//! Offers functionality for reading input from the user.
+
 use std::{cell::RefCell, collections::HashSet};
 
 use promkit_widgets::{

--- a/promkit/src/preset/text.rs
+++ b/promkit/src/preset/text.rs
@@ -1,3 +1,5 @@
+//! Provides a static text display.
+
 use std::cell::RefCell;
 
 use promkit_widgets::text;

--- a/promkit/src/preset/tree.rs
+++ b/promkit/src/preset/tree.rs
@@ -1,3 +1,5 @@
+//! Supports creating and interacting with a tree structure for hierarchical data.
+
 use std::cell::RefCell;
 
 use promkit_widgets::{


### PR DESCRIPTION
This enables Rustdocs to render all the features and mark them as feature-gated.

This method is similar to how crates like Tokio do this.