### PR TITLE
feat: add renderer-managed widget layout and mouse interactions

### DIFF
--- a/Concept.md
+++ b/Concept.md
@@ -14,9 +14,8 @@ promkit is organized around three responsibilities with clear boundaries:
 
 2. **State management and UI materialization (`promkit-widgets` + `promkit-core`)**
    - Each widget state implements [`Widget`](./promkit-core/src/lib.rs).
-   - `Widget::create_graphemes(width, height)` returns
-     [`StyledGraphemes`](./promkit-core/src/grapheme.rs), which is the render-ready
-     text unit including style and line breaks.
+   - `Widget::create_graphemes()` returns `CreatedGraphemes`: width-independent
+     styled content, layout hints, and an optional logical cursor position.
    - Widget states focus on state and projection only.
 
 > [!IMPORTANT]
@@ -25,11 +24,16 @@ promkit is organized around three responsibilities with clear boundaries:
 > which avoids key-binding conflicts when multiple widgets are combined.
 
 3. **Rendering (`promkit-core`)**
-   - [`Renderer<K>`](./promkit-core/src/render.rs) stores ordered grapheme chunks in
-     `SkipMap<K, StyledGraphemes>`.
+   - [`Renderer<K>`](./promkit-core/src/render.rs) stores ordered
+     `CreatedGraphemes` chunks.
    - `update` / `remove` modify chunks by index key.
+   - `render` wraps or truncates content, assigns vertical viewports, scrolls
+     viewports to include logical cursors, and saves a keyed layout snapshot.
+   - The layout snapshot supports screen-to-widget hit testing and the inverse
+     widget-to-screen position mapping.
    - `render` delegates drawing to [`Terminal`](./promkit-core/src/terminal.rs).
-   - `Terminal::draw` performs wrapping, clearing, printing, and scrolling.
+   - `Terminal::draw_rows` performs clearing, printing, and terminal scrolling
+     after layout is complete.
 
 This keeps responsibilities explicit:
 - prompt = control flow

--- a/examples/byop/src/byop.rs
+++ b/examples/byop/src/byop.rs
@@ -17,10 +17,7 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use promkit::{
     anyhow, async_trait,
-    core::{
-        crossterm::{self, style::Color},
-        grapheme::StyledGraphemes,
-    },
+    core::{crossterm::style::Color, grapheme::StyledGraphemes},
     widgets::{
         core::{
             crossterm::{
@@ -172,8 +169,7 @@ impl Prompt for Byop {
 
     async fn evaluate(&mut self, event: &Event) -> anyhow::Result<Signal> {
         let ret = self.evaluate_internal(event).await;
-        let size = crossterm::terminal::size()?;
-        self.render(size.0, size.1).await?;
+        self.render().await?;
         ret
     }
 
@@ -194,8 +190,6 @@ impl Prompt for Byop {
 
 impl Byop {
     async fn try_default() -> anyhow::Result<Self> {
-        let size = crossterm::terminal::size()?;
-
         let readline = text_editor::State {
             config: text_editor::config::Config {
                 prefix: String::from("❯❯ "),
@@ -215,7 +209,7 @@ impl Byop {
 
         let renderer = SharedRenderer::new(
             Renderer::try_new_with_graphemes(
-                [(Index::Readline, readline.create_graphemes(size.0, size.1))],
+                [(Index::Readline, readline.create_graphemes())],
                 true,
             )
             .await?,
@@ -271,11 +265,6 @@ impl Byop {
 
     async fn evaluate_internal(&mut self, event: &Event) -> anyhow::Result<Signal> {
         match event {
-            // Render for refreshing prompt on resize.
-            Event::Resize(width, height) => {
-                self.render(*width, *height).await?;
-            }
-
             // Handle Enter key based on task state
             Event::Key(KeyEvent {
                 code: KeyCode::Enter,
@@ -411,12 +400,9 @@ impl Byop {
         Ok(Signal::Continue)
     }
 
-    async fn render(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+    async fn render(&mut self) -> anyhow::Result<()> {
         self.renderer
-            .update([(
-                Index::Readline,
-                self.readline.create_graphemes(width, height),
-            )])
+            .update([(Index::Readline, self.readline.create_graphemes())])
             .render()
             .await
     }

--- a/promkit-core/src/grapheme.rs
+++ b/promkit-core/src/grapheme.rs
@@ -45,6 +45,10 @@ impl StyledGrapheme {
         self.width
     }
 
+    pub fn character(&self) -> char {
+        self.ch
+    }
+
     pub fn apply_style(&mut self, style: ContentStyle) {
         self.style = style;
     }
@@ -151,6 +155,43 @@ impl StyledGraphemes {
     /// Calculates the total display width of all `Grapheme` instances in the collection.
     pub fn widths(&self) -> usize {
         self.0.iter().map(|grapheme| grapheme.width).sum()
+    }
+
+    /// Calculates the display width before the given grapheme index.
+    pub fn widths_to(&self, index: usize) -> usize {
+        self.0
+            .iter()
+            .take(index)
+            .map(|grapheme| grapheme.width)
+            .sum()
+    }
+
+    /// Splits content at explicit newlines without applying terminal wrapping.
+    pub fn logical_lines(&self) -> Vec<StyledGraphemes> {
+        if self.is_empty() {
+            return Vec::new();
+        }
+
+        let mut lines = Vec::new();
+        let mut line = StyledGraphemes::default();
+        let mut last_was_newline = false;
+
+        for styled in self.iter() {
+            if styled.ch == '\n' {
+                lines.push(line);
+                line = StyledGraphemes::default();
+                last_was_newline = true;
+            } else {
+                line.push_back(styled.clone());
+                last_was_newline = false;
+            }
+        }
+
+        if !line.is_empty() || last_was_newline {
+            lines.push(line);
+        }
+
+        lines
     }
 
     /// Returns a displayable format of the styled graphemes.

--- a/promkit-core/src/lib.rs
+++ b/promkit-core/src/lib.rs
@@ -4,8 +4,9 @@ pub mod grapheme;
 // TODO: reconciliation (detecting differences between old and new grapheme trees)
 pub mod render;
 pub mod terminal;
+pub mod widget;
 
-pub trait Widget {
-    /// Creates styled graphemes with the given width and height.
-    fn create_graphemes(&self, width: u16, height: u16) -> grapheme::StyledGraphemes;
-}
+pub use widget::{
+    ContentPosition, CreatedGraphemes, ScreenPosition, ViewportChange, VisualPosition, Widget,
+    WidgetLayout, WidgetPosition, WidgetViewport, WidthMode,
+};

--- a/promkit-core/src/render.rs
+++ b/promkit-core/src/render.rs
@@ -1,32 +1,85 @@
-use std::sync::Arc;
+//! Terminal-dependent layout, viewport management, drawing, and hit testing.
+//!
+//! [`Renderer`] stores widget outputs in key order. During [`Renderer::render`]
+//! it reads the current terminal size, wraps or truncates every logical content
+//! row, allocates vertical viewports, scrolls each keyed viewport just enough to
+//! include its cursor, and delegates the resulting visible rows to the terminal.
+//!
+//! Empty items and items with `max_height == Some(0)` do not occupy space.
+//! Remaining items are allocated in key order while reserving at least one row
+//! for every later non-empty item. A terminal that cannot provide one row per
+//! non-empty item produces an error.
+//!
+//! A successful render saves a layout snapshot. [`Renderer::hit_test`] and
+//! [`Renderer::screen_position`] always use that snapshot, so event handling maps
+//! positions against what was actually drawn rather than against newer,
+//! not-yet-rendered content.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex, RwLock},
+};
 
 use crossbeam_skiplist::SkipMap;
-use tokio::sync::Mutex;
+use tokio::sync::Mutex as AsyncMutex;
 
-use crate::{grapheme::StyledGraphemes, terminal::Terminal};
+use crate::{
+    grapheme::StyledGraphemes,
+    terminal::Terminal,
+    widget::{
+        ContentPosition, CreatedGraphemes, ScreenPosition, VisualPosition, WidgetPosition,
+        WidgetViewport, WidthMode,
+    },
+};
 
 /// SharedRenderer is a type alias for an Arc-wrapped Renderer, allowing for shared ownership and concurrency.
 pub type SharedRenderer<K> = Arc<Renderer<K>>;
 
-/// Renderer is responsible for managing and rendering multiple grapheme chunks in a terminal.
-pub struct Renderer<K: Ord + Send + 'static> {
-    terminal: Mutex<Terminal>,
-    graphemes: SkipMap<K, StyledGraphemes>,
+#[derive(Clone, Debug)]
+struct VisualRow {
+    content_row: usize,
+    content_column: usize,
+    graphemes: StyledGraphemes,
 }
 
-impl<K: Ord + Send + 'static> Renderer<K> {
+#[derive(Clone, Debug)]
+struct LayoutEntry<K> {
+    index: K,
+    viewport: WidgetViewport,
+    rows: Vec<VisualRow>,
+}
+
+#[derive(Clone, Debug)]
+struct LayoutSnapshot<K> {
+    origin: ScreenPosition,
+    terminal_width: u16,
+    entries: Vec<LayoutEntry<K>>,
+}
+
+/// Renderer stores widget content, lays it out, and draws it to a terminal.
+pub struct Renderer<K: Clone + Ord + Send + Sync + 'static> {
+    terminal: AsyncMutex<Terminal>,
+    contents: SkipMap<K, CreatedGraphemes>,
+    viewport_rows: Mutex<BTreeMap<K, usize>>,
+    layout: RwLock<Option<LayoutSnapshot<K>>>,
+}
+
+impl<K: Clone + Ord + Send + Sync + 'static> Renderer<K> {
     pub fn try_new() -> anyhow::Result<Self> {
         Ok(Self {
-            terminal: Mutex::new(Terminal {
-                position: crossterm::cursor::position()?,
+            terminal: AsyncMutex::new(Terminal {
+                position: crate::crossterm::cursor::position()?,
             }),
-            graphemes: SkipMap::new(),
+            contents: SkipMap::new(),
+            viewport_rows: Mutex::new(BTreeMap::new()),
+            layout: RwLock::new(None),
         })
     }
 
-    pub async fn try_new_with_graphemes<I>(init: I, draw: bool) -> anyhow::Result<Self>
+    pub async fn try_new_with_graphemes<I, G>(init: I, draw: bool) -> anyhow::Result<Self>
     where
-        I: IntoIterator<Item = (K, StyledGraphemes)>,
+        I: IntoIterator<Item = (K, G)>,
+        G: Into<CreatedGraphemes>,
     {
         let renderer = Self::try_new()?;
         renderer.update(init);
@@ -36,12 +89,13 @@ impl<K: Ord + Send + 'static> Renderer<K> {
         Ok(renderer)
     }
 
-    pub fn update<I>(&self, items: I) -> &Self
+    pub fn update<I, G>(&self, items: I) -> &Self
     where
-        I: IntoIterator<Item = (K, StyledGraphemes)>,
+        I: IntoIterator<Item = (K, G)>,
+        G: Into<CreatedGraphemes>,
     {
         items.into_iter().for_each(|(index, graphemes)| {
-            self.graphemes.insert(index, graphemes);
+            self.contents.insert(index, graphemes.into());
         });
         self
     }
@@ -50,20 +104,375 @@ impl<K: Ord + Send + 'static> Renderer<K> {
     where
         I: IntoIterator<Item = K>,
     {
+        let mut viewport_rows = self.viewport_rows.lock().expect("viewport lock poisoned");
         items.into_iter().for_each(|index| {
-            self.graphemes.remove(&index);
+            self.contents.remove(&index);
+            viewport_rows.remove(&index);
         });
         self
     }
 
-    // TODO: Implement diff rendering
-    pub async fn render(&self) -> anyhow::Result<()> {
-        let graphemes: Vec<StyledGraphemes> = self
-            .graphemes
+    /// Returns the content position under a terminal screen position.
+    ///
+    /// This always uses the layout from the most recently completed render.
+    pub fn hit_test(&self, position: ScreenPosition) -> Option<WidgetPosition<K>> {
+        let layout = self.layout.read().ok()?;
+        let layout = layout.as_ref()?;
+
+        if position.column >= layout.terminal_width {
+            return None;
+        }
+
+        let entry = layout.entries.iter().find(|entry| {
+            let start = entry.viewport.screen_row;
+            let end = start.saturating_add(entry.viewport.height);
+            position.row >= start && position.row < end
+        })?;
+
+        let relative_row = position.row.saturating_sub(entry.viewport.screen_row) as usize;
+        let visual_row = entry.viewport.content_row.saturating_add(relative_row);
+        let row = entry.rows.get(visual_row)?;
+
+        let screen_column = if position.row == layout.origin.row {
+            position.column.checked_sub(layout.origin.column)?
+        } else {
+            position.column
+        };
+
+        Some(WidgetPosition {
+            index: entry.index.clone(),
+            row: row.content_row,
+            column: row.content_column.saturating_add(screen_column as usize),
+        })
+    }
+
+    /// Returns the screen position for a widget content position when it is visible.
+    pub fn screen_position(&self, position: WidgetPosition<K>) -> Option<ScreenPosition> {
+        let layout = self.layout.read().ok()?;
+        let layout = layout.as_ref()?;
+        let entry = layout
+            .entries
             .iter()
-            .map(|entry| entry.value().clone())
-            .collect();
+            .find(|entry| entry.index == position.index)?;
+
+        let matching_rows = entry
+            .rows
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| row.content_row == position.row)
+            .collect::<Vec<_>>();
+
+        let (visual_row, row) = matching_rows
+            .iter()
+            .copied()
+            .find(|(_, row)| {
+                let end = row.content_column.saturating_add(row.graphemes.widths());
+                position.column >= row.content_column && position.column < end
+            })
+            .or_else(|| matching_rows.last().copied())?;
+
+        let viewport_end = entry
+            .viewport
+            .content_row
+            .saturating_add(entry.viewport.height as usize);
+        if visual_row < entry.viewport.content_row || visual_row >= viewport_end {
+            return None;
+        }
+
+        let row_offset = visual_row.saturating_sub(entry.viewport.content_row) as u16;
+        let screen_row = entry.viewport.screen_row.saturating_add(row_offset);
+        let row_origin_column = if screen_row == layout.origin.row {
+            layout.origin.column
+        } else {
+            0
+        };
+        let column_offset = position.column.saturating_sub(row.content_column);
+        let column_offset = u16::try_from(column_offset).ok()?;
+        let column = row_origin_column.saturating_add(column_offset);
+
+        (column < layout.terminal_width).then_some(ScreenPosition {
+            row: screen_row,
+            column,
+        })
+    }
+
+    /// Lays out all current widget outputs and renders their visible viewports.
+    ///
+    /// Viewport offsets persist by item key. They remain stable while a cursor is
+    /// visible, move only when it crosses a viewport edge, and are clamped when
+    /// content or terminal dimensions shrink.
+    pub async fn render(&self) -> anyhow::Result<()> {
+        let contents = self
+            .contents
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect::<Vec<_>>();
+
         let mut terminal = self.terminal.lock().await;
-        terminal.draw(&graphemes)
+        let (terminal_width, terminal_height) = crate::crossterm::terminal::size()?;
+        let laid_out = contents
+            .into_iter()
+            .map(|(index, created)| {
+                let rows = layout_content(&created, terminal_width as usize);
+                (index, created, rows)
+            })
+            .filter(|(_, created, rows)| !rows.is_empty() && created.layout.max_height != Some(0))
+            .collect::<Vec<_>>();
+
+        if laid_out.len() > terminal_height as usize {
+            return Err(anyhow::anyhow!("Insufficient space to display all panes"));
+        }
+
+        let mut viewport_rows = self.viewport_rows.lock().expect("viewport lock poisoned");
+        let mut entries = Vec::with_capacity(laid_out.len());
+        let mut panes = Vec::with_capacity(laid_out.len());
+        let mut used_height = 0usize;
+
+        for (pane_index, (index, created, rows)) in laid_out.iter().enumerate() {
+            let panes_after = laid_out.len().saturating_sub(pane_index + 1);
+            let available = (terminal_height as usize)
+                .saturating_sub(used_height)
+                .saturating_sub(panes_after);
+            let desired = created
+                .layout
+                .max_height
+                .unwrap_or(rows.len())
+                .min(rows.len());
+            let height = desired.min(available).max(1);
+            used_height = used_height.saturating_add(height);
+
+            let mut viewport = WidgetViewport {
+                height: height as u16,
+                content_row: viewport_rows.get(index).copied().unwrap_or_default(),
+                ..Default::default()
+            };
+
+            let max_content_row = rows.len().saturating_sub(height);
+            viewport.content_row = viewport.content_row.min(max_content_row);
+
+            if let Some(cursor) = created.cursor
+                && let Some(position) = visual_position(rows, cursor)
+            {
+                viewport.scroll_to_include(position);
+                viewport.content_row = viewport.content_row.min(max_content_row);
+            }
+
+            viewport_rows.insert(index.clone(), viewport.content_row);
+            let visible_rows = rows
+                .iter()
+                .skip(viewport.content_row)
+                .take(height)
+                .map(|row| row.graphemes.clone())
+                .collect::<Vec<_>>();
+
+            panes.push(visible_rows);
+            entries.push(LayoutEntry {
+                index: index.clone(),
+                viewport,
+                rows: rows.clone(),
+            });
+        }
+        drop(viewport_rows);
+
+        terminal.draw_rows(&panes)?;
+
+        let origin = ScreenPosition {
+            row: terminal.position.1,
+            column: terminal.position.0,
+        };
+        let mut screen_row = origin.row;
+        for entry in &mut entries {
+            entry.viewport.screen_row = screen_row;
+            screen_row = screen_row.saturating_add(entry.viewport.height);
+        }
+
+        *self.layout.write().expect("layout lock poisoned") = Some(LayoutSnapshot {
+            origin,
+            terminal_width,
+            entries,
+        });
+
+        Ok(())
+    }
+}
+
+fn layout_content(created: &CreatedGraphemes, width: usize) -> Vec<VisualRow> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    created
+        .graphemes
+        .logical_lines()
+        .into_iter()
+        .enumerate()
+        .flat_map(|(content_row, line)| match created.layout.width_mode {
+            WidthMode::Wrap => wrap_line(content_row, line, width),
+            WidthMode::Truncate => vec![VisualRow {
+                content_row,
+                content_column: 0,
+                graphemes: line.truncated_line_with_ellipsis(width, &StyledGraphemes::from("…")),
+            }],
+        })
+        .collect()
+}
+
+fn wrap_line(content_row: usize, line: StyledGraphemes, width: usize) -> Vec<VisualRow> {
+    if line.is_empty() {
+        return vec![VisualRow {
+            content_row,
+            content_column: 0,
+            graphemes: line,
+        }];
+    }
+
+    let mut rows = Vec::new();
+    let mut row = StyledGraphemes::default();
+    let mut row_width = 0usize;
+    let mut content_column = 0usize;
+    let mut row_column = 0usize;
+
+    for grapheme in line.iter() {
+        let grapheme_width = grapheme.width();
+        if grapheme_width > width {
+            content_column = content_column.saturating_add(grapheme_width);
+            continue;
+        }
+
+        if !row.is_empty() && row_width.saturating_add(grapheme_width) > width {
+            rows.push(VisualRow {
+                content_row,
+                content_column: row_column,
+                graphemes: row,
+            });
+            row = StyledGraphemes::default();
+            row_width = 0;
+            row_column = content_column;
+        }
+
+        row.push_back(grapheme.clone());
+        row_width = row_width.saturating_add(grapheme_width);
+        content_column = content_column.saturating_add(grapheme_width);
+    }
+
+    if !row.is_empty() {
+        rows.push(VisualRow {
+            content_row,
+            content_column: row_column,
+            graphemes: row,
+        });
+    }
+
+    rows
+}
+
+fn visual_position(rows: &[VisualRow], position: ContentPosition) -> Option<VisualPosition> {
+    let matching = rows
+        .iter()
+        .enumerate()
+        .filter(|(_, row)| row.content_row == position.row)
+        .collect::<Vec<_>>();
+
+    let (row_index, row) = matching
+        .iter()
+        .copied()
+        .find(|(_, row)| {
+            let end = row.content_column.saturating_add(row.graphemes.widths());
+            position.column >= row.content_column && position.column < end
+        })
+        .or_else(|| matching.last().copied())?;
+
+    Some(VisualPosition {
+        row: row_index,
+        column: position.column.saturating_sub(row.content_column),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widget::{WidgetLayout, WidthMode};
+
+    #[test]
+    fn layout_maps_logical_cursor_to_wrapped_row() {
+        let created = CreatedGraphemes {
+            graphemes: StyledGraphemes::from("abcdefghij"),
+            cursor: Some(ContentPosition { row: 0, column: 8 }),
+            ..Default::default()
+        };
+        let rows = layout_content(&created, 4);
+
+        assert_eq!(rows.len(), 3);
+        assert_eq!(
+            visual_position(&rows, created.cursor.unwrap()),
+            Some(VisualPosition { row: 2, column: 0 })
+        );
+    }
+
+    #[test]
+    fn truncate_keeps_one_visual_row_per_logical_row() {
+        let created = CreatedGraphemes {
+            graphemes: StyledGraphemes::from("abcdefghij\nsecond"),
+            layout: WidgetLayout {
+                width_mode: WidthMode::Truncate,
+                ..Default::default()
+            },
+            cursor: None,
+        };
+        let rows = layout_content(&created, 4);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].graphemes.to_string(), "abc…");
+        assert_eq!(rows[1].graphemes.to_string(), "sec…");
+    }
+
+    #[test]
+    fn hit_test_and_screen_position_round_trip() {
+        let renderer = Renderer {
+            terminal: AsyncMutex::new(Terminal { position: (0, 0) }),
+            contents: SkipMap::new(),
+            viewport_rows: Mutex::new(BTreeMap::new()),
+            layout: RwLock::new(Some(LayoutSnapshot {
+                origin: ScreenPosition { row: 3, column: 0 },
+                terminal_width: 20,
+                entries: vec![LayoutEntry {
+                    index: 7usize,
+                    viewport: WidgetViewport {
+                        screen_row: 3,
+                        height: 2,
+                        content_row: 1,
+                    },
+                    rows: vec![
+                        VisualRow {
+                            content_row: 0,
+                            content_column: 0,
+                            graphemes: StyledGraphemes::from("hidden"),
+                        },
+                        VisualRow {
+                            content_row: 1,
+                            content_column: 0,
+                            graphemes: StyledGraphemes::from("first"),
+                        },
+                        VisualRow {
+                            content_row: 2,
+                            content_column: 0,
+                            graphemes: StyledGraphemes::from("second"),
+                        },
+                    ],
+                }],
+            })),
+        };
+
+        let screen = ScreenPosition { row: 4, column: 2 };
+        let widget = renderer.hit_test(screen).unwrap();
+        assert_eq!(
+            widget,
+            WidgetPosition {
+                index: 7,
+                row: 2,
+                column: 2,
+            }
+        );
+        assert_eq!(renderer.screen_position(widget), Some(screen));
     }
 }

--- a/promkit-core/src/render.rs
+++ b/promkit-core/src/render.rs
@@ -335,7 +335,25 @@ fn wrap_line(content_row: usize, line: StyledGraphemes, width: usize) -> Vec<Vis
     for grapheme in line.iter() {
         let grapheme_width = grapheme.width();
         if grapheme_width > width {
+            if !row.is_empty() {
+                rows.push(VisualRow {
+                    content_row,
+                    content_column: row_column,
+                    graphemes: row,
+                });
+                row = StyledGraphemes::default();
+                row_width = 0;
+            }
+
+            // Keep the replacement on its own visual row: it occupies one screen
+            // cell while the original grapheme still advances by its logical width.
+            rows.push(VisualRow {
+                content_row,
+                content_column,
+                graphemes: StyledGraphemes::from("…"),
+            });
             content_column = content_column.saturating_add(grapheme_width);
+            row_column = content_column;
             continue;
         }
 
@@ -426,6 +444,27 @@ mod tests {
         assert_eq!(
             visual_position(&rows, created.cursor.unwrap()),
             Some(VisualPosition { row: 0, column: 0 })
+        );
+    }
+
+    #[test]
+    fn wrap_preserves_columns_after_a_grapheme_wider_than_the_terminal() {
+        let created = CreatedGraphemes {
+            graphemes: StyledGraphemes::from("界a"),
+            cursor: Some(ContentPosition { row: 0, column: 2 }),
+            ..Default::default()
+        };
+
+        let rows = layout_content(&created, 1);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].content_column, 0);
+        assert_eq!(rows[0].graphemes.to_string(), "…");
+        assert_eq!(rows[1].content_column, 2);
+        assert_eq!(rows[1].graphemes.to_string(), "a");
+        assert_eq!(
+            visual_position(&rows, created.cursor.unwrap()),
+            Some(VisualPosition { row: 1, column: 0 })
         );
     }
 

--- a/promkit-core/src/render.rs
+++ b/promkit-core/src/render.rs
@@ -410,6 +410,26 @@ mod tests {
     }
 
     #[test]
+    fn wrap_preserves_a_grapheme_wider_than_the_terminal() {
+        let created = CreatedGraphemes {
+            graphemes: StyledGraphemes::from("界"),
+            cursor: Some(ContentPosition { row: 0, column: 0 }),
+            ..Default::default()
+        };
+
+        let rows = layout_content(&created, 1);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].content_row, 0);
+        assert_eq!(rows[0].content_column, 0);
+        assert_eq!(rows[0].graphemes.to_string(), "…");
+        assert_eq!(
+            visual_position(&rows, created.cursor.unwrap()),
+            Some(VisualPosition { row: 0, column: 0 })
+        );
+    }
+
+    #[test]
     fn truncate_keeps_one_visual_row_per_logical_row() {
         let created = CreatedGraphemes {
             graphemes: StyledGraphemes::from("abcdefghij\nsecond"),

--- a/promkit-core/src/terminal.rs
+++ b/promkit-core/src/terminal.rs
@@ -11,10 +11,9 @@ pub struct Terminal {
 }
 
 impl Terminal {
+    /// Draws content that still needs terminal-width wrapping.
     pub fn draw(&mut self, graphemes: &[StyledGraphemes]) -> anyhow::Result<()> {
         let (width, height) = terminal::size()?;
-        let visible_height = height.saturating_sub(self.position.1);
-
         let viewable_rows = graphemes
             .iter()
             .map(|graphemes| graphemes.wrapped_lines(width as usize))
@@ -25,23 +24,38 @@ impl Terminal {
             return Err(anyhow::anyhow!("Insufficient space to display all panes"));
         }
 
+        let mut used = 0;
+        let mut panes = Vec::with_capacity(viewable_rows.len());
+        for (pane_index, rows) in viewable_rows.iter().enumerate() {
+            let max_rows = 1
+                .max((height as usize).saturating_sub(used + viewable_rows.len() - 1 - pane_index));
+            let rows = rows.iter().take(max_rows).cloned().collect::<Vec<_>>();
+            used += rows.len();
+            panes.push(rows);
+        }
+
+        self.draw_rows(&panes)
+    }
+
+    /// Draws panes that have already been wrapped and clipped by the renderer.
+    pub fn draw_rows(&mut self, panes: &[Vec<StyledGraphemes>]) -> anyhow::Result<()> {
+        let (_, height) = terminal::size()?;
+        let visible_height = height.saturating_sub(self.position.1);
+        let row_count = panes.iter().map(Vec::len).sum::<usize>();
+
+        if row_count > height as usize {
+            return Err(anyhow::anyhow!("Insufficient space to display all panes"));
+        }
+
         crossterm::queue!(
             io::stdout(),
             cursor::MoveTo(self.position.0, self.position.1),
             terminal::Clear(terminal::ClearType::FromCursorDown),
         )?;
 
-        let mut used = 0;
-
         let mut remaining_lines = visible_height;
 
-        for (pane_index, rows) in viewable_rows.iter().enumerate() {
-            let max_rows = 1
-                .max((height as usize).saturating_sub(used + viewable_rows.len() - 1 - pane_index));
-            let rows = rows.iter().take(max_rows).collect::<Vec<_>>();
-            let row_count = rows.len();
-            used += row_count;
-
+        for (pane_index, rows) in panes.iter().enumerate() {
             for (row_index, row) in rows.iter().enumerate() {
                 crossterm::queue!(io::stdout(), style::Print(row.styled_display()))?;
 
@@ -50,8 +64,8 @@ impl Terminal {
                 // Determine if scrolling is needed:
                 // - We need to scroll if we've reached the bottom of the terminal (remaining_lines == 0)
                 // - AND we have more content to display (either more rows in current pane or more panes)
-                let is_last_pane = pane_index == viewable_rows.len() - 1;
-                let is_last_row_in_pane = row_index == row_count - 1;
+                let is_last_pane = pane_index == panes.len() - 1;
+                let is_last_row_in_pane = row_index == rows.len() - 1;
                 let has_more_content = !(is_last_pane && is_last_row_in_pane);
 
                 if has_more_content && remaining_lines == 0 {

--- a/promkit-core/src/widget.rs
+++ b/promkit-core/src/widget.rs
@@ -1,0 +1,193 @@
+//! Width-independent widget output and the coordinate types used during layout.
+//!
+//! Widgets project state into their complete styled content without receiving a
+//! terminal size or viewport. Alongside that content they return a [`WidgetLayout`]
+//! hint and, when applicable, a logical [`ContentPosition`] for the cursor.
+//! [`crate::render::Renderer`] owns terminal-dependent wrapping, truncation,
+//! vertical viewport allocation, and scrolling.
+//!
+//! Positions deliberately have three coordinate spaces:
+//!
+//! - [`ContentPosition`] addresses newline-delimited widget content. Its column is
+//!   measured in terminal display cells.
+//! - [`VisualPosition`] addresses the rows produced after terminal-width layout.
+//! - [`ScreenPosition`] addresses absolute terminal cells.
+//!
+//! The renderer records the mapping between these spaces after every completed
+//! render so it can support cursor placement and hit testing.
+
+use crate::grapheme::StyledGraphemes;
+
+/// A widget's position in its width-independent, newline-delimited content.
+///
+/// `column` is a terminal display-cell offset, not a character index.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ContentPosition {
+    pub row: usize,
+    pub column: usize,
+}
+
+/// A position after the content has been wrapped for a terminal width.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct VisualPosition {
+    pub row: usize,
+    pub column: usize,
+}
+
+/// A position on the terminal screen.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ScreenPosition {
+    pub row: u16,
+    pub column: u16,
+}
+
+/// A content position associated with a renderer item.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WidgetPosition<K> {
+    pub index: K,
+    pub row: usize,
+    pub column: usize,
+}
+
+impl<K> WidgetPosition<K> {
+    pub fn content_position(&self) -> ContentPosition {
+        ContentPosition {
+            row: self.row,
+            column: self.column,
+        }
+    }
+}
+
+/// Horizontal overflow behavior applied by the renderer.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum WidthMode {
+    /// Continue content on subsequent visual rows.
+    #[default]
+    Wrap,
+    /// Keep one visual row per logical row and append an ellipsis when needed.
+    Truncate,
+}
+
+/// Layout constraints requested by a widget.
+///
+/// `max_height` is a preference rather than a terminal allocation. The renderer
+/// combines it with the laid-out content height, terminal height, and the other
+/// non-empty widgets. `width_mode` controls whether each logical row wraps or is
+/// truncated with an ellipsis.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WidgetLayout {
+    pub max_height: Option<usize>,
+    pub width_mode: WidthMode,
+}
+
+/// Width-independent content and metadata created by a widget.
+///
+/// `graphemes` contains the widget's complete content, not only its visible
+/// window. This lets the renderer preserve a viewport while a cursor moves inside
+/// it and scroll only when the cursor crosses an edge.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CreatedGraphemes {
+    pub graphemes: StyledGraphemes,
+    pub layout: WidgetLayout,
+    pub cursor: Option<ContentPosition>,
+}
+
+impl From<StyledGraphemes> for CreatedGraphemes {
+    fn from(graphemes: StyledGraphemes) -> Self {
+        Self {
+            graphemes,
+            ..Self::default()
+        }
+    }
+}
+
+/// A viewport assigned to one renderer item.
+///
+/// `content_row` is a row in the terminal-width-dependent visual layout.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WidgetViewport {
+    pub screen_row: u16,
+    pub height: u16,
+    pub content_row: usize,
+}
+
+impl WidgetViewport {
+    /// Scrolls the minimum distance needed to include `position`.
+    ///
+    /// Moving inside the current viewport leaves `content_row` unchanged.
+    pub fn scroll_to_include(&mut self, position: VisualPosition) -> ViewportChange {
+        if self.height == 0 {
+            return ViewportChange::Unchanged;
+        }
+
+        let previous = self.content_row;
+        let height = self.height as usize;
+
+        if position.row < self.content_row {
+            self.content_row = position.row;
+        } else if position.row >= self.content_row.saturating_add(height) {
+            self.content_row = position.row.saturating_add(1).saturating_sub(height);
+        }
+
+        if self.content_row == previous {
+            ViewportChange::Unchanged
+        } else {
+            ViewportChange::Scrolled
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ViewportChange {
+    Unchanged,
+    Scrolled,
+}
+
+/// Projects widget state into complete, width-independent styled content.
+///
+/// Implementations must not inspect the terminal size or apply viewport
+/// clipping. Terminal-dependent work belongs to [`crate::render::Renderer`].
+pub trait Widget {
+    fn create_graphemes(&self) -> CreatedGraphemes;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn viewport_does_not_scroll_while_position_is_visible() {
+        let mut viewport = WidgetViewport {
+            height: 3,
+            content_row: 4,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            viewport.scroll_to_include(VisualPosition { row: 6, column: 0 }),
+            ViewportChange::Unchanged
+        );
+        assert_eq!(viewport.content_row, 4);
+    }
+
+    #[test]
+    fn viewport_scrolls_the_minimum_distance() {
+        let mut viewport = WidgetViewport {
+            height: 3,
+            content_row: 4,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            viewport.scroll_to_include(VisualPosition { row: 7, column: 0 }),
+            ViewportChange::Scrolled
+        );
+        assert_eq!(viewport.content_row, 5);
+
+        assert_eq!(
+            viewport.scroll_to_include(VisualPosition { row: 2, column: 0 }),
+            ViewportChange::Scrolled
+        );
+        assert_eq!(viewport.content_row, 2);
+    }
+}

--- a/promkit-widgets/src/checkbox.rs
+++ b/promkit-widgets/src/checkbox.rs
@@ -66,3 +66,43 @@ impl Widget for State {
         }
     }
 }
+
+impl State {
+    /// Interprets a checkbox content position as a toggleable item.
+    ///
+    /// Wrapped visual rows are normalized to their logical content row by the
+    /// core renderer before this method resolves the item index.
+    pub fn hit_at(&self, position: ContentPosition) -> Option<CheckboxHit> {
+        self.checkbox
+            .items()
+            .get(position.row)
+            .map(|_| CheckboxHit::Toggle {
+                index: position.row,
+            })
+    }
+}
+
+/// Semantic targets exposed by the checkbox widget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheckboxHit {
+    Toggle { index: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_item_rows_for_hits() {
+        let state = State {
+            checkbox: Checkbox::from_displayable(["first", "second"]),
+            config: Config::default(),
+        };
+
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 1, column: 20 }),
+            Some(CheckboxHit::Toggle { index: 1 })
+        );
+        assert_eq!(state.hit_at(ContentPosition { row: 2, column: 0 }), None);
+    }
+}

--- a/promkit-widgets/src/checkbox.rs
+++ b/promkit-widgets/src/checkbox.rs
@@ -1,4 +1,6 @@
-use promkit_core::{Widget, grapheme::StyledGraphemes};
+use promkit_core::{
+    ContentPosition, CreatedGraphemes, Widget, WidgetLayout, grapheme::StyledGraphemes,
+};
 
 #[path = "checkbox/checkbox.rs"]
 mod inner;
@@ -22,7 +24,7 @@ pub struct State {
 }
 
 impl Widget for State {
-    fn create_graphemes(&self, _width: u16, height: u16) -> StyledGraphemes {
+    fn create_graphemes(&self) -> CreatedGraphemes {
         let f = |idx: usize| -> StyledGraphemes {
             if self.checkbox.picked_indexes().contains(&idx) {
                 StyledGraphemes::from(format!("{} ", self.config.active_mark))
@@ -31,39 +33,36 @@ impl Widget for State {
             }
         };
 
-        let height = match self.config.lines {
-            Some(lines) => lines.min(height as usize),
-            None => height as usize,
-        };
+        let lines = self.checkbox.items().iter().enumerate().map(|(i, item)| {
+            if i == self.checkbox.position() {
+                StyledGraphemes::from_iter([
+                    &StyledGraphemes::from(&self.config.cursor),
+                    &f(i),
+                    item,
+                ])
+                .apply_style(self.config.active_item_style)
+            } else {
+                StyledGraphemes::from_iter([
+                    &StyledGraphemes::from(
+                        " ".repeat(StyledGraphemes::from(&self.config.cursor).widths()),
+                    ),
+                    &f(i),
+                    item,
+                ])
+                .apply_style(self.config.inactive_item_style)
+            }
+        });
 
-        let lines = self
-            .checkbox
-            .items()
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| {
-                *i >= self.checkbox.position() && *i < self.checkbox.position() + height
-            })
-            .map(|(i, item)| {
-                if i == self.checkbox.position() {
-                    StyledGraphemes::from_iter([
-                        &StyledGraphemes::from(&self.config.cursor),
-                        &f(i),
-                        item,
-                    ])
-                    .apply_style(self.config.active_item_style)
-                } else {
-                    StyledGraphemes::from_iter([
-                        &StyledGraphemes::from(
-                            " ".repeat(StyledGraphemes::from(&self.config.cursor).widths()),
-                        ),
-                        &f(i),
-                        item,
-                    ])
-                    .apply_style(self.config.inactive_item_style)
-                }
-            });
-
-        StyledGraphemes::from_lines(lines)
+        CreatedGraphemes {
+            graphemes: StyledGraphemes::from_lines(lines),
+            layout: WidgetLayout {
+                max_height: self.config.lines,
+                ..Default::default()
+            },
+            cursor: (!self.checkbox.items().is_empty()).then_some(ContentPosition {
+                row: self.checkbox.position(),
+                column: 0,
+            }),
+        }
     }
 }

--- a/promkit-widgets/src/checkbox/checkbox.rs
+++ b/promkit-widgets/src/checkbox/checkbox.rs
@@ -98,6 +98,18 @@ impl Checkbox {
         }
     }
 
+    /// Moves to an item by index and toggles its selection state.
+    ///
+    /// Returns `false` without changing the checkbox when the index is out of
+    /// bounds.
+    pub fn toggle_at(&mut self, index: usize) -> bool {
+        if !self.listbox.move_to(index) {
+            return false;
+        }
+        self.toggle();
+        true
+    }
+
     /// Moves the cursor backward in the listbox, if possible.
     /// Returns `true` if the cursor was successfully moved backward, `false` otherwise.
     pub fn backward(&mut self) -> bool {

--- a/promkit-widgets/src/listbox.rs
+++ b/promkit-widgets/src/listbox.rs
@@ -1,4 +1,6 @@
-use promkit_core::{Widget, grapheme::StyledGraphemes};
+use promkit_core::{
+    ContentPosition, CreatedGraphemes, Widget, WidgetLayout, grapheme::StyledGraphemes,
+};
 
 #[path = "listbox/listbox.rs"]
 mod inner;
@@ -18,44 +20,41 @@ pub struct State {
 }
 
 impl Widget for State {
-    fn create_graphemes(&self, _width: u16, height: u16) -> StyledGraphemes {
-        let height = match self.config.lines {
-            Some(lines) => lines.min(height as usize),
-            None => height as usize,
-        };
-
-        let lines = self
-            .listbox
-            .items()
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| *i >= self.listbox.position() && *i < self.listbox.position() + height)
-            .map(|(i, item)| {
-                if i == self.listbox.position() {
-                    let init = StyledGraphemes::from_iter([
-                        &StyledGraphemes::from(&self.config.cursor),
-                        item,
-                    ]);
-                    if let Some(style) = &self.config.active_item_style {
-                        init.apply_style(*style)
-                    } else {
-                        init
-                    }
+    fn create_graphemes(&self) -> CreatedGraphemes {
+        let lines = self.listbox.items().iter().enumerate().map(|(i, item)| {
+            if i == self.listbox.position() {
+                let init =
+                    StyledGraphemes::from_iter([&StyledGraphemes::from(&self.config.cursor), item]);
+                if let Some(style) = &self.config.active_item_style {
+                    init.apply_style(*style)
                 } else {
-                    let init = StyledGraphemes::from_iter([
-                        &StyledGraphemes::from(
-                            " ".repeat(StyledGraphemes::from(&self.config.cursor).widths()),
-                        ),
-                        item,
-                    ]);
-                    if let Some(style) = &self.config.inactive_item_style {
-                        init.apply_style(*style)
-                    } else {
-                        init
-                    }
+                    init
                 }
-            });
+            } else {
+                let init = StyledGraphemes::from_iter([
+                    &StyledGraphemes::from(
+                        " ".repeat(StyledGraphemes::from(&self.config.cursor).widths()),
+                    ),
+                    item,
+                ]);
+                if let Some(style) = &self.config.inactive_item_style {
+                    init.apply_style(*style)
+                } else {
+                    init
+                }
+            }
+        });
 
-        StyledGraphemes::from_lines(lines)
+        CreatedGraphemes {
+            graphemes: StyledGraphemes::from_lines(lines),
+            layout: WidgetLayout {
+                max_height: self.config.lines,
+                ..Default::default()
+            },
+            cursor: (!self.listbox.is_empty()).then_some(ContentPosition {
+                row: self.listbox.position(),
+                column: 0,
+            }),
+        }
     }
 }

--- a/promkit-widgets/src/listbox.rs
+++ b/promkit-widgets/src/listbox.rs
@@ -58,3 +58,43 @@ impl Widget for State {
         }
     }
 }
+
+impl State {
+    /// Interprets a listbox content position as a selectable item.
+    ///
+    /// Wrapped visual rows are normalized to their logical content row by the
+    /// core renderer before this method resolves the item index.
+    pub fn hit_at(&self, position: ContentPosition) -> Option<ListboxHit> {
+        self.listbox
+            .items()
+            .get(position.row)
+            .map(|_| ListboxHit::Select {
+                index: position.row,
+            })
+    }
+}
+
+/// Semantic targets exposed by the listbox widget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ListboxHit {
+    Select { index: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_item_rows_for_hits() {
+        let state = State {
+            listbox: Listbox::from(["first", "second"]),
+            config: Config::default(),
+        };
+
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 1, column: 20 }),
+            Some(ListboxHit::Select { index: 1 })
+        );
+        assert_eq!(state.hit_at(ContentPosition { row: 2, column: 0 }), None);
+    }
+}

--- a/promkit-widgets/src/listbox/listbox.rs
+++ b/promkit-widgets/src/listbox/listbox.rs
@@ -82,6 +82,11 @@ impl Listbox {
         self.0.forward()
     }
 
+    /// Moves the cursor to an item by index.
+    pub fn move_to(&mut self, position: usize) -> bool {
+        self.0.move_to(position)
+    }
+
     /// Moves the cursor to the head (beginning) of the listbox.
     pub fn move_to_head(&mut self) {
         self.0.move_to_head()

--- a/promkit-widgets/src/spinner.rs
+++ b/promkit-widgets/src/spinner.rs
@@ -60,7 +60,7 @@ pub async fn run<S, I>(
 ) -> anyhow::Result<()>
 where
     S: State,
-    I: Clone + Ord + Send,
+    I: Clone + Ord + Send + Sync + 'static,
 {
     let mut frame_index = 0;
     let mut interval = tokio::time::interval(spinner.duration);

--- a/promkit-widgets/src/status.rs
+++ b/promkit-widgets/src/status.rs
@@ -1,7 +1,6 @@
 use promkit_core::{
-    Widget,
+    CreatedGraphemes, Widget,
     crossterm::style::{Color, ContentStyle},
-    grapheme::StyledGraphemes,
 };
 
 use crate::text::{State as TextState, Text};
@@ -56,7 +55,7 @@ impl State {
 }
 
 impl Widget for State {
-    fn create_graphemes(&self, width: u16, height: u16) -> StyledGraphemes {
-        self.text.create_graphemes(width, height)
+    fn create_graphemes(&self) -> CreatedGraphemes {
+        self.text.create_graphemes()
     }
 }

--- a/promkit-widgets/src/structured/json.rs
+++ b/promkit-widgets/src/structured/json.rs
@@ -1,4 +1,6 @@
-use promkit_core::{Widget, grapheme::StyledGraphemes};
+use promkit_core::{
+    ContentPosition, CreatedGraphemes, Widget, WidgetLayout, WidthMode, grapheme::StyledGraphemes,
+};
 
 mod document;
 pub use document::Document;
@@ -24,16 +26,25 @@ pub struct State {
 }
 
 impl Widget for State {
-    fn create_graphemes(&self, width: u16, height: u16) -> StyledGraphemes {
-        let height = match self.config.lines {
-            Some(lines) => lines.min(height as usize),
-            None => height as usize,
-        };
+    fn create_graphemes(&self) -> CreatedGraphemes {
+        let rows = self.document.visible_rows();
+        let active_row = self.document.visible_position();
+        let formatted_rows = self.config.render_content_rows(&rows, active_row);
 
-        let rows = self.document.extract_rows_from_current(height);
-        let formatted_rows = self.config.render_terminal_rows(&rows, width);
-
-        StyledGraphemes::from_lines(formatted_rows)
+        CreatedGraphemes {
+            graphemes: StyledGraphemes::from_lines(formatted_rows),
+            layout: WidgetLayout {
+                max_height: self.config.lines,
+                width_mode: match self.config.overflow_mode {
+                    config::OverflowMode::Truncate => WidthMode::Truncate,
+                    config::OverflowMode::Wrap => WidthMode::Wrap,
+                },
+            },
+            cursor: (!rows.is_empty()).then_some(ContentPosition {
+                row: active_row,
+                column: 0,
+            }),
+        }
     }
 }
 
@@ -42,4 +53,20 @@ impl State {
     pub fn render_pretty_json(&self) -> String {
         self.document.rows().render_pretty(self.config.indent)
     }
+
+    /// Interprets a JSON content position as a semantic operation target.
+    ///
+    /// Wrapped visual rows are normalized to their logical content row by the
+    /// core renderer before this method resolves the underlying document row.
+    pub fn hit_at(&self, position: ContentPosition) -> Option<JsonHit> {
+        self.document
+            .row_index_at_visible_position(position.row)
+            .map(|row_index| JsonHit::Toggle { row_index })
+    }
+}
+
+/// Semantic targets exposed by the JSON widget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JsonHit {
+    Toggle { row_index: usize },
 }

--- a/promkit-widgets/src/structured/json/config.rs
+++ b/promkit-widgets/src/structured/json/config.rs
@@ -112,10 +112,23 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Formats a Vec<Row> into Vec<StyledGraphemes> with appropriate styling and width limits
+    /// Formats a `Vec<Row>` into `Vec<StyledGraphemes>` with styling and width limits.
     pub fn render_terminal_rows(&self, rows: &[Row], width: u16) -> Vec<StyledGraphemes> {
+        self.render_rows(rows, 0, Some(width as usize))
+    }
+
+    /// Formats width-independent rows for the core renderer.
+    pub fn render_content_rows(&self, rows: &[Row], active_row: usize) -> Vec<StyledGraphemes> {
+        self.render_rows(rows, active_row, None)
+    }
+
+    fn render_rows(
+        &self,
+        rows: &[Row],
+        active_row: usize,
+        width: Option<usize>,
+    ) -> Vec<StyledGraphemes> {
         let mut formatted = Vec::new();
-        let width = width as usize;
 
         for (i, row) in rows.iter().enumerate() {
             let indent = StyledGraphemes::from(" ".repeat(self.indent * row.depth));
@@ -191,18 +204,18 @@ impl Config {
             }
 
             if i + 1 < rows.len() {
-                if matches!(
+                let next_is_close = matches!(
                     &rows[i + 1].node,
                     JsonNode::Container(ContainerNode::Close { .. })
-                ) {
-                } else if matches!(
+                );
+                let current_is_open = matches!(
                     &rows[i].node,
                     JsonNode::Container(ContainerNode::Open {
                         collapsed: false,
                         ..
                     })
-                ) {
-                } else {
+                );
+                if !next_is_close && !current_is_open {
                     parts.push(StyledGraphemes::from(","));
                 }
             }
@@ -212,7 +225,7 @@ impl Config {
             // Note that `extract_rows_from_current`
             // returns rows starting from the current position,
             // so the first row should always be highlighted as active
-            content = content.apply_attribute(if i == 0 {
+            content = content.apply_attribute(if i == active_row {
                 self.active_item_attribute
             } else {
                 self.inactive_item_attribute
@@ -220,14 +233,19 @@ impl Config {
 
             let mut line: StyledGraphemes = vec![indent, content].into_iter().collect();
 
-            match self.overflow_mode {
-                OverflowMode::Truncate => {
-                    line = line.truncated_line_with_ellipsis(width, &StyledGraphemes::from("…"));
-                    formatted.push(line);
+            if let Some(width) = width {
+                match self.overflow_mode {
+                    OverflowMode::Truncate => {
+                        line =
+                            line.truncated_line_with_ellipsis(width, &StyledGraphemes::from("…"));
+                        formatted.push(line);
+                    }
+                    OverflowMode::Wrap => {
+                        formatted.extend(line.wrapped_lines(width));
+                    }
                 }
-                OverflowMode::Wrap => {
-                    formatted.extend(line.wrapped_lines(width));
-                }
+            } else {
+                formatted.push(line);
             }
         }
 

--- a/promkit-widgets/src/structured/json/document.rs
+++ b/promkit-widgets/src/structured/json/document.rs
@@ -27,10 +27,32 @@ impl Document {
         self.rows.extract(self.position, n)
     }
 
+    /// Returns all currently visible rows from the beginning of the document.
+    pub fn visible_rows(&self) -> Vec<Row> {
+        self.rows.extract(self.rows.head(), usize::MAX)
+    }
+
+    /// Returns the selected row's index in the visible row sequence.
+    pub fn visible_position(&self) -> usize {
+        visible_position(&self.rows, self.position)
+    }
+
     /// Toggles the visibility of a node at the cursor's current position.
     pub fn toggle(&mut self) {
         let index = self.rows.toggle(self.position);
         self.position = index;
+    }
+
+    /// Toggles the row identified by its underlying document index.
+    pub fn toggle_at(&mut self, row_index: usize) {
+        if row_index < self.rows.len() {
+            self.position = self.rows.toggle(row_index);
+        }
+    }
+
+    /// Resolves a visible row number to its underlying document index.
+    pub fn row_index_at_visible_position(&self, visible_position: usize) -> Option<usize> {
+        row_index_at_visible_position(&self.rows, visible_position)
     }
 
     /// Sets the visibility of all rows.
@@ -66,4 +88,36 @@ impl Document {
         self.position = self.rows.tail();
         true
     }
+}
+
+fn visible_position(rows: &Vec<Row>, target: usize) -> usize {
+    let mut position = rows.head();
+    let mut visible = 0;
+
+    while position != target {
+        let next = rows.down(position);
+        if next == position {
+            break;
+        }
+        position = next;
+        visible += 1;
+    }
+
+    visible
+}
+
+fn row_index_at_visible_position(rows: &Vec<Row>, target: usize) -> Option<usize> {
+    if rows.is_empty() {
+        return None;
+    }
+
+    let mut position = rows.head();
+    for _ in 0..target {
+        let next = rows.down(position);
+        if next == position {
+            return None;
+        }
+        position = next;
+    }
+    Some(position)
 }

--- a/promkit-widgets/src/structured/tree.rs
+++ b/promkit-widgets/src/structured/tree.rs
@@ -1,4 +1,6 @@
-use promkit_core::{Widget, grapheme::StyledGraphemes};
+use promkit_core::{
+    ContentPosition, CreatedGraphemes, Widget, WidgetLayout, grapheme::StyledGraphemes,
+};
 
 mod document;
 pub use document::Document;
@@ -16,7 +18,7 @@ pub struct State {
 }
 
 impl Widget for State {
-    fn create_graphemes(&self, _width: u16, height: u16) -> StyledGraphemes {
+    fn create_graphemes(&self) -> CreatedGraphemes {
         let symbol = |row: &Row| -> &str {
             if row.has_children && !row.collapsed {
                 &self.config.unfolded_symbol
@@ -25,14 +27,10 @@ impl Widget for State {
             }
         };
 
-        let height = match self.config.lines {
-            Some(lines) => lines.min(height as usize),
-            None => height as usize,
-        };
-
-        let rows = self.document.extract_rows_from_current(height);
+        let rows = self.document.visible_rows();
+        let active_row = self.document.visible_position();
         let lines = rows.iter().enumerate().map(|(offset, row)| {
-            if offset == 0 {
+            if offset == active_row {
                 StyledGraphemes::from_str(
                     format!(
                         "{}{}{}",
@@ -55,6 +53,16 @@ impl Widget for State {
             }
         });
 
-        StyledGraphemes::from_lines(lines)
+        CreatedGraphemes {
+            graphemes: StyledGraphemes::from_lines(lines),
+            layout: WidgetLayout {
+                max_height: self.config.lines,
+                ..Default::default()
+            },
+            cursor: (!rows.is_empty()).then_some(ContentPosition {
+                row: active_row,
+                column: 0,
+            }),
+        }
     }
 }

--- a/promkit-widgets/src/structured/tree.rs
+++ b/promkit-widgets/src/structured/tree.rs
@@ -66,3 +66,55 @@ impl Widget for State {
         }
     }
 }
+
+impl State {
+    /// Interprets a tree content position as a semantic operation target.
+    ///
+    /// Wrapped visual rows are normalized to their logical content row by the
+    /// core renderer before this method resolves the underlying document row.
+    pub fn hit_at(&self, position: ContentPosition) -> Option<TreeHit> {
+        self.document
+            .row_index_at_visible_position(position.row)
+            .map(|row_index| TreeHit::Toggle { row_index })
+    }
+}
+
+/// Semantic targets exposed by the tree widget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TreeHit {
+    Toggle { row_index: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_visible_rows_for_hits() {
+        let state = State {
+            document: Document::new(vec![
+                Row {
+                    id: "root".into(),
+                    path: vec!["root".into()],
+                    depth: 0,
+                    has_children: true,
+                    collapsed: false,
+                },
+                Row {
+                    id: "child".into(),
+                    path: vec!["root".into(), "child".into()],
+                    depth: 1,
+                    has_children: false,
+                    collapsed: false,
+                },
+            ]),
+            config: Config::default(),
+        };
+
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 1, column: 20 }),
+            Some(TreeHit::Toggle { row_index: 1 })
+        );
+        assert_eq!(state.hit_at(ContentPosition { row: 2, column: 0 }), None);
+    }
+}

--- a/promkit-widgets/src/structured/tree/document.rs
+++ b/promkit-widgets/src/structured/tree/document.rs
@@ -38,6 +38,16 @@ impl Document {
         self.rows.extract(self.position, n)
     }
 
+    /// Returns all currently visible rows from the beginning of the document.
+    pub fn visible_rows(&self) -> Vec<Row> {
+        self.rows.extract(self.rows.head(), usize::MAX)
+    }
+
+    /// Returns the selected row's index in the visible row sequence.
+    pub fn visible_position(&self) -> usize {
+        visible_position(&self.rows, self.position)
+    }
+
     /// Toggles the visibility of a node at the cursor's current position.
     pub fn toggle(&mut self) {
         let index = self.rows.toggle(self.position);
@@ -77,4 +87,20 @@ impl Document {
         self.position = self.rows.tail();
         true
     }
+}
+
+fn visible_position(rows: &Vec<Row>, target: usize) -> usize {
+    let mut position = rows.head();
+    let mut visible = 0;
+
+    while position != target {
+        let next = rows.down(position);
+        if next == position {
+            break;
+        }
+        position = next;
+        visible += 1;
+    }
+
+    visible
 }

--- a/promkit-widgets/src/structured/tree/document.rs
+++ b/promkit-widgets/src/structured/tree/document.rs
@@ -54,6 +54,18 @@ impl Document {
         self.position = index;
     }
 
+    /// Toggles the row identified by its underlying document index.
+    pub fn toggle_at(&mut self, row_index: usize) {
+        if row_index < self.rows.len() {
+            self.position = self.rows.toggle(row_index);
+        }
+    }
+
+    /// Resolves a visible row number to its underlying document index.
+    pub fn row_index_at_visible_position(&self, visible_position: usize) -> Option<usize> {
+        row_index_at_visible_position(&self.rows, visible_position)
+    }
+
     /// Sets the visibility of all rows.
     pub fn set_nodes_visibility(&mut self, collapsed: bool) {
         self.rows.set_rows_visibility(collapsed);
@@ -103,4 +115,20 @@ fn visible_position(rows: &Vec<Row>, target: usize) -> usize {
     }
 
     visible
+}
+
+fn row_index_at_visible_position(rows: &Vec<Row>, target: usize) -> Option<usize> {
+    if rows.is_empty() {
+        return None;
+    }
+
+    let mut position = rows.head();
+    for _ in 0..target {
+        let next = rows.down(position);
+        if next == position {
+            return None;
+        }
+        position = next;
+    }
+    Some(position)
 }

--- a/promkit-widgets/src/structured/yaml.rs
+++ b/promkit-widgets/src/structured/yaml.rs
@@ -1,4 +1,6 @@
-use promkit_core::{Widget, grapheme::StyledGraphemes};
+use promkit_core::{
+    ContentPosition, CreatedGraphemes, Widget, WidgetLayout, WidthMode, grapheme::StyledGraphemes,
+};
 
 mod document;
 pub use document::Document;
@@ -17,15 +19,74 @@ pub struct State {
 }
 
 impl Widget for State {
-    fn create_graphemes(&self, width: u16, height: u16) -> StyledGraphemes {
-        let height = match self.config.lines {
-            Some(lines) => lines.min(height as usize),
-            None => height as usize,
+    fn create_graphemes(&self) -> CreatedGraphemes {
+        let rows = self.document.visible_rows();
+        let active_row = self.document.visible_position();
+        let formatted_rows = self.config.render_content_rows(&rows, active_row);
+
+        CreatedGraphemes {
+            graphemes: StyledGraphemes::from_lines(formatted_rows),
+            layout: WidgetLayout {
+                max_height: self.config.lines,
+                width_mode: match self.config.overflow_mode {
+                    config::OverflowMode::Truncate => WidthMode::Truncate,
+                    config::OverflowMode::Wrap => WidthMode::Wrap,
+                },
+            },
+            cursor: (!rows.is_empty()).then_some(ContentPosition {
+                row: active_row,
+                column: 0,
+            }),
+        }
+    }
+}
+
+impl State {
+    /// Interprets a YAML content position as a semantic operation target.
+    ///
+    /// The logical content row is resolved back to the underlying document row,
+    /// including YAML sequence mappings whose source rows are merged into one
+    /// displayed line. Wrapped visual rows are already normalized to their
+    /// logical content row by the core renderer.
+    pub fn hit_at(&self, position: ContentPosition) -> Option<YamlHit> {
+        self.document
+            .row_index_at_visible_position(position.row)
+            .map(|row_index| YamlHit::Toggle { row_index })
+    }
+}
+
+/// Semantic targets exposed by the YAML widget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum YamlHit {
+    Toggle { row_index: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_full_content_and_resolves_visible_rows_for_hits() {
+        let value =
+            serde_yaml::from_str("first: one\nsecond:\n  nested: two\nthird: three\n").unwrap();
+        let mut state = State {
+            document: Document::new([&value]),
+            config: Config::default(),
         };
 
-        let rows = self.document.extract_rows_from_current(height);
-        let formatted_rows = self.config.render_terminal_rows(&rows, width);
+        let initial = state.create_graphemes();
+        assert!(initial.graphemes.to_string().contains("first: one"));
+        assert!(initial.graphemes.to_string().contains("third: three"));
+        assert_eq!(initial.cursor.unwrap().row, 0);
 
-        StyledGraphemes::from_lines(formatted_rows)
+        state.document.down();
+        let moved = state.create_graphemes();
+        assert!(moved.graphemes.to_string().contains("first: one"));
+        assert_eq!(moved.cursor.unwrap().row, 1);
+
+        assert!(matches!(
+            state.hit_at(ContentPosition { row: 1, column: 4 }),
+            Some(YamlHit::Toggle { .. })
+        ));
     }
 }

--- a/promkit-widgets/src/structured/yaml/config.rs
+++ b/promkit-widgets/src/structured/yaml/config.rs
@@ -164,12 +164,12 @@ impl Config {
         StyledGraphemes::from(typ.collapsed_preview()).apply_style(style)
     }
 
-    fn render_node(&self, row: &Row, node: &YamlNode) -> Option<StyledGraphemes> {
+    fn render_node(&self, node: &YamlNode) -> Option<StyledGraphemes> {
         match node {
             YamlNode::Tagged { tag, node } => {
                 let tag_part =
                     StyledGraphemes::from(format!("{} ", tag)).apply_style(self.tag_style);
-                match self.render_node(row, node) {
+                match self.render_node(node) {
                     Some(value) => Some(vec![tag_part, value].into_iter().collect()),
                     None => Some(tag_part),
                 }
@@ -202,12 +202,25 @@ impl Config {
 
     /// Format YAML rows into terminal lines with styling and width constraints.
     pub fn render_terminal_rows(&self, rows: &[Row], width: u16) -> Vec<StyledGraphemes> {
+        self.render_rows(rows, 0, Some(width as usize))
+    }
+
+    /// Formats width-independent rows for the core renderer.
+    pub fn render_content_rows(&self, rows: &[Row], active_row: usize) -> Vec<StyledGraphemes> {
+        self.render_rows(rows, active_row, None)
+    }
+
+    fn render_rows(
+        &self,
+        rows: &[Row],
+        active_row: usize,
+        width: Option<usize>,
+    ) -> Vec<StyledGraphemes> {
         let mut formatted = Vec::new();
-        let width = width as usize;
         let mut i = 0;
+        let mut rendered_row = 0;
 
         while i < rows.len() {
-            let source_index = i;
             let row = &rows[i];
 
             // Collection roots occupy depth 0 as an operation row, so their
@@ -233,7 +246,7 @@ impl Config {
                     parts.push(StyledGraphemes::from(": "));
                 }
 
-                if let Some(value) = self.render_node(row, &row.node) {
+                if let Some(value) = self.render_node(&row.node) {
                     parts.push(value);
                 }
 
@@ -245,29 +258,27 @@ impl Config {
                         ..
                     })
                 ) && row.is_sequence_item
+                    && let Some(next_row) = rows.get(i + 1)
+                    && next_row.depth == row.depth + 1
+                    && !next_row.is_sequence_item
+                    && let Some(key) = &next_row.key
                 {
-                    if let Some(next_row) = rows.get(i + 1) {
-                        if next_row.depth == row.depth + 1 && !next_row.is_sequence_item {
-                            if let Some(key) = &next_row.key {
-                                parts.push(
-                                    StyledGraphemes::from(Self::render_yaml_string(key))
-                                        .apply_style(self.key_style),
-                                );
-                                parts.push(StyledGraphemes::from(": "));
+                    parts.push(
+                        StyledGraphemes::from(Self::render_yaml_string(key))
+                            .apply_style(self.key_style),
+                    );
+                    parts.push(StyledGraphemes::from(": "));
 
-                                if let Some(value) = self.render_node(next_row, &next_row.node) {
-                                    parts.push(value);
-                                }
-
-                                i += 1;
-                            }
-                        }
+                    if let Some(value) = self.render_node(&next_row.node) {
+                        parts.push(value);
                     }
+
+                    i += 1;
                 }
             }
 
             let mut content: StyledGraphemes = parts.into_iter().collect();
-            content = content.apply_attribute(if source_index == 0 {
+            content = content.apply_attribute(if rendered_row == active_row {
                 self.active_item_attribute
             } else {
                 self.inactive_item_attribute
@@ -275,17 +286,23 @@ impl Config {
 
             let mut line: StyledGraphemes = vec![indent, content].into_iter().collect();
 
-            match self.overflow_mode {
-                OverflowMode::Truncate => {
-                    line = line.truncated_line_with_ellipsis(width, &StyledGraphemes::from("…"));
-                    formatted.push(line);
+            if let Some(width) = width {
+                match self.overflow_mode {
+                    OverflowMode::Truncate => {
+                        line =
+                            line.truncated_line_with_ellipsis(width, &StyledGraphemes::from("…"));
+                        formatted.push(line);
+                    }
+                    OverflowMode::Wrap => {
+                        formatted.extend(line.wrapped_lines(width));
+                    }
                 }
-                OverflowMode::Wrap => {
-                    formatted.extend(line.wrapped_lines(width));
-                }
+            } else {
+                formatted.push(line);
             }
 
             i += 1;
+            rendered_row += 1;
         }
 
         formatted

--- a/promkit-widgets/src/structured/yaml/document.rs
+++ b/promkit-widgets/src/structured/yaml/document.rs
@@ -26,6 +26,16 @@ impl Document {
         self.rows.extract(self.position, n)
     }
 
+    /// Returns all currently visible rows from the beginning of the document.
+    pub fn visible_rows(&self) -> Vec<Row> {
+        self.rows.extract(self.rows.head(), usize::MAX)
+    }
+
+    /// Returns the selected row's index in the rendered visible row sequence.
+    pub fn visible_position(&self) -> usize {
+        visible_position(&self.rows, self.position)
+    }
+
     /// Toggles the container value associated with the YAML key at the cursor.
     ///
     /// The displayed key determines the toggle target:
@@ -40,6 +50,18 @@ impl Document {
     pub fn toggle(&mut self) {
         let index = self.rows.toggle(self.position);
         self.position = index;
+    }
+
+    /// Toggles the row identified by its underlying document index.
+    pub fn toggle_at(&mut self, row_index: usize) {
+        if row_index < self.rows.len() {
+            self.position = self.rows.toggle(row_index);
+        }
+    }
+
+    /// Resolves a rendered visible row number to its underlying document index.
+    pub fn row_index_at_visible_position(&self, visible_position: usize) -> Option<usize> {
+        row_index_at_visible_position(&self.rows, visible_position)
     }
 
     /// Sets the visibility of all rows.
@@ -75,4 +97,36 @@ impl Document {
         self.position = self.rows.tail();
         true
     }
+}
+
+fn visible_position(rows: &Vec<Row>, target: usize) -> usize {
+    let mut position = rows.head();
+    let mut visible = 0;
+
+    while position != target {
+        let next = rows.down(position);
+        if next == position {
+            break;
+        }
+        position = next;
+        visible += 1;
+    }
+
+    visible
+}
+
+fn row_index_at_visible_position(rows: &Vec<Row>, target: usize) -> Option<usize> {
+    if rows.is_empty() {
+        return None;
+    }
+
+    let mut position = rows.head();
+    for _ in 0..target {
+        let next = rows.down(position);
+        if next == position {
+            return None;
+        }
+        position = next;
+    }
+    Some(position)
 }

--- a/promkit-widgets/src/text.rs
+++ b/promkit-widgets/src/text.rs
@@ -53,3 +53,43 @@ impl Widget for State {
         }
     }
 }
+
+impl State {
+    /// Interprets a text content position as a selectable line.
+    ///
+    /// Wrapped visual rows are normalized to their logical content row by the
+    /// core renderer before this method resolves the line index.
+    pub fn hit_at(&self, position: ContentPosition) -> Option<TextHit> {
+        self.text
+            .items()
+            .get(position.row)
+            .map(|_| TextHit::Select {
+                index: position.row,
+            })
+    }
+}
+
+/// Semantic targets exposed by the text widget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TextHit {
+    Select { index: usize },
+}
+
+#[cfg(test)]
+mod state_tests {
+    use super::*;
+
+    #[test]
+    fn resolves_line_rows_for_hits() {
+        let state = State {
+            text: Text::from("first\nsecond"),
+            config: Config::default(),
+        };
+
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 1, column: 20 }),
+            Some(TextHit::Select { index: 1 })
+        );
+        assert_eq!(state.hit_at(ContentPosition { row: 2, column: 0 }), None);
+    }
+}

--- a/promkit-widgets/src/text.rs
+++ b/promkit-widgets/src/text.rs
@@ -1,4 +1,6 @@
-use promkit_core::{Widget, grapheme::StyledGraphemes};
+use promkit_core::{
+    ContentPosition, CreatedGraphemes, Widget, WidgetLayout, grapheme::StyledGraphemes,
+};
 
 #[path = "text/text.rs"]
 mod inner;
@@ -29,26 +31,25 @@ impl State {
 }
 
 impl Widget for State {
-    fn create_graphemes(&self, _width: u16, height: u16) -> StyledGraphemes {
-        let height = match self.config.lines {
-            Some(lines) => lines.min(height as usize),
-            None => height as usize,
-        };
+    fn create_graphemes(&self) -> CreatedGraphemes {
+        let lines = self.text.items().iter().map(|item| {
+            if let Some(style) = &self.config.style {
+                item.clone().apply_style(*style)
+            } else {
+                item.clone()
+            }
+        });
 
-        let lines = self
-            .text
-            .items()
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| *i >= self.text.position() && *i < self.text.position() + height)
-            .map(|(_, item)| {
-                if let Some(style) = &self.config.style {
-                    item.clone().apply_style(*style)
-                } else {
-                    item.clone()
-                }
-            });
-
-        StyledGraphemes::from_lines(lines)
+        CreatedGraphemes {
+            graphemes: StyledGraphemes::from_lines(lines),
+            layout: WidgetLayout {
+                max_height: self.config.lines,
+                ..Default::default()
+            },
+            cursor: (!self.text.items().is_empty()).then_some(ContentPosition {
+                row: self.text.position(),
+                column: 0,
+            }),
+        }
     }
 }

--- a/promkit-widgets/src/text/text.rs
+++ b/promkit-widgets/src/text/text.rs
@@ -62,6 +62,11 @@ impl Text {
     pub fn forward(&mut self) -> bool {
         self.0.forward()
     }
+
+    /// Moves the cursor to a line by index.
+    pub fn move_to(&mut self, position: usize) -> bool {
+        self.0.move_to(position)
+    }
 }
 
 #[cfg(test)]

--- a/promkit-widgets/src/text_editor.rs
+++ b/promkit-widgets/src/text_editor.rs
@@ -1,4 +1,6 @@
-use promkit_core::{Widget, grapheme::StyledGraphemes};
+use promkit_core::{
+    ContentPosition, CreatedGraphemes, Widget, WidgetLayout, grapheme::StyledGraphemes,
+};
 
 mod history;
 pub use history::History;
@@ -20,11 +22,7 @@ pub struct State {
 }
 
 impl Widget for State {
-    fn create_graphemes(&self, width: u16, height: u16) -> StyledGraphemes {
-        if width == 0 {
-            return StyledGraphemes::default();
-        }
-
+    fn create_graphemes(&self) -> CreatedGraphemes {
         let mut buf = StyledGraphemes::default();
 
         let mut styled_prefix =
@@ -37,6 +35,7 @@ impl Widget for State {
             Some(mask) => self.texteditor.masking(mask),
             None => self.texteditor.text(),
         };
+        let cursor_column = prefix_width + text.widths_to(self.texteditor.position());
 
         let mut styled = text
             .apply_style(self.config.inactive_char_style)
@@ -44,23 +43,16 @@ impl Widget for State {
 
         buf.append(&mut styled);
 
-        let height = match self.config.lines {
-            Some(lines) => lines.min(height as usize),
-            None => height as usize,
-        };
-
-        let rows = buf.wrapped_lines(width as usize);
-        if rows.is_empty() || height == 0 {
-            return StyledGraphemes::default();
+        CreatedGraphemes {
+            graphemes: buf,
+            layout: WidgetLayout {
+                max_height: self.config.lines,
+                ..Default::default()
+            },
+            cursor: Some(ContentPosition {
+                row: 0,
+                column: cursor_column,
+            }),
         }
-
-        let lines = rows.len().min(height);
-        let mut start = (prefix_width + self.texteditor.position()) / width as usize;
-        let end = start + lines;
-        if end > rows.len() {
-            start = rows.len().saturating_sub(lines);
-        }
-
-        StyledGraphemes::from_lines(rows.into_iter().skip(start).take(lines))
     }
 }

--- a/promkit-widgets/src/text_editor.rs
+++ b/promkit-widgets/src/text_editor.rs
@@ -56,3 +56,109 @@ impl Widget for State {
         }
     }
 }
+
+impl State {
+    /// Interprets a text-editor content position as a cursor target.
+    ///
+    /// The prefix occupies content columns but is not editable, so clicking it
+    /// resolves to the start of the input. Columns inside wide characters resolve
+    /// to that character, and columns beyond the rendered input resolve to the
+    /// trailing cursor position. Masked input is measured using the mask that is
+    /// actually displayed.
+    pub fn hit_at(&self, position: ContentPosition) -> Option<TextEditorHit> {
+        if position.row != 0 {
+            return None;
+        }
+
+        let prefix_width = StyledGraphemes::from(&self.config.prefix).widths();
+        let input_column = position.column.saturating_sub(prefix_width);
+        let rendered = match self.config.mask {
+            Some(mask) => self.texteditor.masking(mask),
+            None => self.texteditor.text(),
+        };
+
+        let mut start = 0;
+        let index = rendered
+            .iter()
+            .enumerate()
+            .find_map(|(index, grapheme)| {
+                let end = start + grapheme.width();
+                let contains = input_column < end;
+                start = end;
+                contains.then_some(index)
+            })
+            .unwrap_or_else(|| rendered.len().saturating_sub(1));
+
+        Some(TextEditorHit::Cursor { index })
+    }
+}
+
+/// Semantic targets exposed by the text-editor widget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TextEditorHit {
+    Cursor { index: usize },
+}
+
+#[cfg(test)]
+mod state_tests {
+    use super::*;
+
+    fn state(text: &str, prefix: &str) -> State {
+        State {
+            texteditor: TextEditor::new(text),
+            config: Config {
+                prefix: prefix.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolves_prefix_input_and_trailing_columns() {
+        let state = state("abc", ">> ");
+
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 0, column: 1 }),
+            Some(TextEditorHit::Cursor { index: 0 })
+        );
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 0, column: 4 }),
+            Some(TextEditorHit::Cursor { index: 1 })
+        );
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 0, column: 80 }),
+            Some(TextEditorHit::Cursor { index: 3 })
+        );
+        assert_eq!(state.hit_at(ContentPosition { row: 1, column: 0 }), None);
+    }
+
+    #[test]
+    fn resolves_columns_inside_wide_characters() {
+        let state = state("界a", "");
+
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 0, column: 0 }),
+            Some(TextEditorHit::Cursor { index: 0 })
+        );
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 0, column: 1 }),
+            Some(TextEditorHit::Cursor { index: 0 })
+        );
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 0, column: 2 }),
+            Some(TextEditorHit::Cursor { index: 1 })
+        );
+    }
+
+    #[test]
+    fn uses_the_rendered_mask_width() {
+        let mut state = state("界a", "");
+        state.config.mask = Some('*');
+
+        assert_eq!(
+            state.hit_at(ContentPosition { row: 0, column: 1 }),
+            Some(TextEditorHit::Cursor { index: 1 })
+        );
+    }
+}

--- a/promkit-widgets/src/text_editor/text_editor.rs
+++ b/promkit-widgets/src/text_editor/text_editor.rs
@@ -200,6 +200,11 @@ impl TextEditor {
         self.0.move_to_tail()
     }
 
+    /// Moves the cursor to a character by index.
+    pub fn move_to(&mut self, position: usize) -> bool {
+        self.0.move_to(position)
+    }
+
     pub fn shift(&mut self, backward: usize, forward: usize) -> bool {
         self.0.shift(backward, forward)
     }

--- a/promkit/src/lib.rs
+++ b/promkit/src/lib.rs
@@ -25,7 +25,7 @@ use core::crossterm::{
 
 /// Singleton for EventStream. If a new EventStream is created for each Prompt::run,
 /// it causes the error "The cursor position could not be read within a normal duration".
-/// See https://github.com/crossterm-rs/crossterm/issues/963#issuecomment-2571259264 for more details.
+/// See <https://github.com/crossterm-rs/crossterm/issues/963#issuecomment-2571259264> for details.
 pub static EVENT_STREAM: LazyLock<Mutex<EventStream>> =
     LazyLock::new(|| Mutex::new(EventStream::new()));
 
@@ -94,6 +94,11 @@ pub trait Prompt {
     /// to handle events until a quit signal is received.
     /// After exiting the loop, it produces and returns the result.
     ///
+    /// Raw mode and mouse capture are enabled for the duration of the prompt.
+    /// Resize events are not redrawn immediately because terminals already reflow
+    /// their current screen; the next input-triggered render observes the new size
+    /// and refreshes content, viewports, and hit-test layout.
+    ///
     /// # Returns
     ///
     /// Returns a `Result` containing the produced result or an error.
@@ -109,16 +114,16 @@ pub trait Prompt {
         };
 
         enable_raw_mode()?;
-        execute!(io::stdout(), cursor::Hide)?;
+        execute!(io::stdout(), cursor::Hide, event::EnableMouseCapture,)?;
 
         self.initialize().await?;
 
         while let Some(event) = EVENT_STREAM.lock().await.next().await {
             match event {
                 Ok(event) => {
-                    // NOTE: For zsh_pretend/tests/resize_roundtrip_wrap_reflow.rs, skipping
-                    // resize events here
-                    // keeps output closer to zsh than evaluating resize as a normal input event.
+                    // Terminals reflow the existing screen on resize. Redrawing here
+                    // changes the prompt origin and causes an extra vertical shift.
+                    // The renderer observes the new size on the next input event.
                     if event.is_resize() {
                         continue;
                     }

--- a/promkit/src/preset/checkbox.rs
+++ b/promkit/src/preset/checkbox.rs
@@ -5,7 +5,6 @@ use std::fmt::Display;
 use crate::{
     core::{
         crossterm::{
-            self,
             event::Event,
             style::{Attribute, Attributes, Color, ContentStyle},
         },
@@ -23,7 +22,7 @@ use crate::{
 pub mod evaluate;
 
 /// Represents the indices of various components in the checkbox preset.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Index {
     Title = 0,
     Checkbox = 1,
@@ -45,15 +44,11 @@ pub struct Checkbox {
 #[async_trait::async_trait]
 impl crate::Prompt for Checkbox {
     async fn initialize(&mut self) -> anyhow::Result<()> {
-        let size = crossterm::terminal::size()?;
         self.renderer = Some(SharedRenderer::new(
             Renderer::try_new_with_graphemes(
                 [
-                    (Index::Title, self.title.create_graphemes(size.0, size.1)),
-                    (
-                        Index::Checkbox,
-                        self.checkbox.create_graphemes(size.0, size.1),
-                    ),
+                    (Index::Title, self.title.create_graphemes()),
+                    (Index::Checkbox, self.checkbox.create_graphemes()),
                 ],
                 true,
             )
@@ -64,8 +59,7 @@ impl crate::Prompt for Checkbox {
 
     async fn evaluate(&mut self, event: &Event) -> anyhow::Result<Signal> {
         let ret = (self.evaluator)(event, self).await;
-        let size = crossterm::terminal::size()?;
-        self.render(size.0, size.1).await?;
+        self.render().await?;
         ret
     }
 
@@ -173,16 +167,13 @@ impl Checkbox {
     }
 
     /// Render the prompt with the specified width and height.
-    async fn render(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+    async fn render(&mut self) -> anyhow::Result<()> {
         match self.renderer.as_ref() {
             Some(renderer) => {
                 renderer
                     .update([
-                        (Index::Title, self.title.create_graphemes(width, height)),
-                        (
-                            Index::Checkbox,
-                            self.checkbox.create_graphemes(width, height),
-                        ),
+                        (Index::Title, self.title.create_graphemes()),
+                        (Index::Checkbox, self.checkbox.create_graphemes()),
                     ])
                     .render()
                     .await

--- a/promkit/src/preset/checkbox/evaluate.rs
+++ b/promkit/src/preset/checkbox/evaluate.rs
@@ -1,9 +1,13 @@
 use crate::{
-    core::crossterm::event::{
-        Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent,
-        MouseEventKind,
+    core::{
+        crossterm::event::{
+            Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+            MouseEvent, MouseEventKind,
+        },
+        ScreenPosition,
     },
-    preset::checkbox::Checkbox,
+    preset::checkbox::{Checkbox, Index},
+    widgets::checkbox::CheckboxHit,
     Signal,
 };
 
@@ -16,6 +20,7 @@ use crate::{
 /// | <kbd>↑</kbd>           | Move the selection up
 /// | <kbd>↓</kbd>           | Move the selection down
 /// | <kbd>Space</kbd>       | Toggle the checkbox state for the current item
+/// | Left click             | Move to and toggle the clicked item
 pub async fn default(event: &Event, ctx: &mut Checkbox) -> anyhow::Result<Signal> {
     match event {
         // Quit
@@ -73,6 +78,31 @@ pub async fn default(event: &Event, ctx: &mut Checkbox) -> anyhow::Result<Signal
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         }) => ctx.checkbox.checkbox.toggle(),
+
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }) => {
+            let renderer = ctx.renderer.clone();
+            if let Some(position) = renderer
+                .as_ref()
+                .and_then(|renderer| {
+                    renderer.hit_test(ScreenPosition {
+                        row: *row,
+                        column: *column,
+                    })
+                })
+                .filter(|position| position.index == Index::Checkbox)
+            {
+                if let Some(CheckboxHit::Toggle { index }) =
+                    ctx.checkbox.hit_at(position.content_position())
+                {
+                    ctx.checkbox.checkbox.toggle_at(index);
+                }
+            }
+        }
 
         _ => (),
     }

--- a/promkit/src/preset/checkbox/evaluate.rs
+++ b/promkit/src/preset/checkbox/evaluate.rs
@@ -18,11 +18,6 @@ use crate::{
 /// | <kbd>Space</kbd>       | Toggle the checkbox state for the current item
 pub async fn default(event: &Event, ctx: &mut Checkbox) -> anyhow::Result<Signal> {
     match event {
-        // Render for refreshing prompt on resize.
-        Event::Resize(width, height) => {
-            ctx.render(*width, *height).await?;
-        }
-
         // Quit
         Event::Key(KeyEvent {
             code: KeyCode::Enter,

--- a/promkit/src/preset/form.rs
+++ b/promkit/src/preset/form.rs
@@ -3,7 +3,6 @@
 use crate::{
     core::{
         crossterm::{
-            self,
             event::Event,
             style::{Attribute, Attributes, ContentStyle},
         },
@@ -47,14 +46,13 @@ impl crate::Prompt for Form {
         // Update styles based on the current position.
         self.overwrite_styles();
 
-        let size = crossterm::terminal::size()?;
         self.renderer = Some(SharedRenderer::new(
             Renderer::try_new_with_graphemes(
                 self.readlines
                     .contents()
                     .iter()
                     .enumerate()
-                    .map(|(i, state)| (i, state.create_graphemes(size.0, size.1))),
+                    .map(|(i, state)| (i, state.create_graphemes())),
                 true,
             )
             .await?,
@@ -68,8 +66,7 @@ impl crate::Prompt for Form {
         // Update the styles based on the current position.
         self.overwrite_styles();
 
-        let size = crossterm::terminal::size()?;
-        self.render(size.0, size.1).await?;
+        self.render().await?;
         ret
     }
 
@@ -131,7 +128,7 @@ impl Form {
     }
 
     /// Render the prompt with the specified width and height.
-    async fn render(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+    async fn render(&mut self) -> anyhow::Result<()> {
         match self.renderer.as_ref() {
             Some(renderer) => {
                 renderer
@@ -140,7 +137,7 @@ impl Form {
                             .contents()
                             .iter()
                             .enumerate()
-                            .map(|(i, state)| (i, state.create_graphemes(width, height))),
+                            .map(|(i, state)| (i, state.create_graphemes())),
                     )
                     .render()
                     .await

--- a/promkit/src/preset/form/evaluate.rs
+++ b/promkit/src/preset/form/evaluate.rs
@@ -1,8 +1,15 @@
 use promkit_widgets::text_editor;
 
 use crate::{
-    core::crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers},
+    core::{
+        crossterm::event::{
+            Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+            MouseEvent, MouseEventKind,
+        },
+        ScreenPosition,
+    },
     preset::form::Form,
+    widgets::text_editor::TextEditorHit,
     Signal,
 };
 
@@ -158,6 +165,34 @@ pub async fn default(event: &Event, ctx: &mut Form) -> anyhow::Result<Signal> {
             state: KeyEventState::NONE,
         }) => {
             ctx.readlines.forward();
+        }
+
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }) => {
+            let renderer = ctx.renderer.clone();
+            if let Some(position) = renderer.as_ref().and_then(|renderer| {
+                renderer.hit_test(ScreenPosition {
+                    row: *row,
+                    column: *column,
+                })
+            }) {
+                let field_index = position.index;
+                if let Some(TextEditorHit::Cursor { index }) = ctx
+                    .readlines
+                    .contents()
+                    .get(field_index)
+                    .and_then(|state| state.hit_at(position.content_position()))
+                {
+                    ctx.readlines.move_to(field_index);
+                    ctx.readlines.contents_mut()[field_index]
+                        .texteditor
+                        .move_to(index);
+                }
+            }
         }
 
         // Input char.

--- a/promkit/src/preset/form/evaluate.rs
+++ b/promkit/src/preset/form/evaluate.rs
@@ -11,11 +11,6 @@ pub async fn default(event: &Event, ctx: &mut Form) -> anyhow::Result<Signal> {
     let current_position = ctx.readlines.position();
 
     match event {
-        // Render for refreshing prompt on resize.
-        Event::Resize(width, height) => {
-            ctx.render(*width, *height).await?;
-        }
-
         // Quit
         Event::Key(KeyEvent {
             code: KeyCode::Enter,

--- a/promkit/src/preset/json.rs
+++ b/promkit/src/preset/json.rs
@@ -3,7 +3,6 @@
 use crate::{
     core::{
         crossterm::{
-            self,
             event::Event,
             style::{Attribute, Attributes, Color, ContentStyle},
         },
@@ -25,7 +24,7 @@ use crate::{
 pub mod evaluate;
 
 /// Represents the indices of various components in the JSON preset.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Index {
     Title = 0,
     Json = 1,
@@ -46,12 +45,11 @@ pub struct Json {
 #[async_trait::async_trait]
 impl crate::Prompt for Json {
     async fn initialize(&mut self) -> anyhow::Result<()> {
-        let size = crossterm::terminal::size()?;
         self.renderer = Some(SharedRenderer::new(
             Renderer::try_new_with_graphemes(
                 [
-                    (Index::Title, self.title.create_graphemes(size.0, size.1)),
-                    (Index::Json, self.json.create_graphemes(size.0, size.1)),
+                    (Index::Title, self.title.create_graphemes()),
+                    (Index::Json, self.json.create_graphemes()),
                 ],
                 true,
             )
@@ -62,8 +60,7 @@ impl crate::Prompt for Json {
 
     async fn evaluate(&mut self, event: &Event) -> anyhow::Result<Signal> {
         let ret = (self.evaluator)(event, self).await;
-        let size = crossterm::terminal::size()?;
-        self.render(size.0, size.1).await?;
+        self.render().await?;
         ret
     }
 
@@ -174,13 +171,13 @@ impl Json {
     }
 
     /// Render the prompt with the specified width and height.
-    async fn render(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+    async fn render(&mut self) -> anyhow::Result<()> {
         match self.renderer.as_ref() {
             Some(renderer) => {
                 renderer
                     .update([
-                        (Index::Title, self.title.create_graphemes(width, height)),
-                        (Index::Json, self.json.create_graphemes(width, height)),
+                        (Index::Title, self.title.create_graphemes()),
+                        (Index::Json, self.json.create_graphemes()),
                     ])
                     .render()
                     .await

--- a/promkit/src/preset/json/evaluate.rs
+++ b/promkit/src/preset/json/evaluate.rs
@@ -1,9 +1,13 @@
 use crate::{
-    core::crossterm::event::{
-        Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent,
-        MouseEventKind,
+    core::{
+        crossterm::event::{
+            Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+            MouseEvent, MouseEventKind,
+        },
+        ScreenPosition,
     },
-    preset::json::Json,
+    preset::json::{Index, Json},
+    widgets::json::JsonHit,
     Signal,
 };
 
@@ -16,13 +20,9 @@ use crate::{
 /// | <kbd>↑</kbd>           | Move the cursor up to the previous node
 /// | <kbd>↓</kbd>           | Move the cursor down to the next node
 /// | <kbd>Space</kbd>       | Toggle fold/unfold on the current node
+/// | Left click             | Toggle fold/unfold on the clicked node
 pub async fn default(event: &Event, ctx: &mut Json) -> anyhow::Result<Signal> {
     match event {
-        // Render for refreshing prompt on resize.
-        Event::Resize(width, height) => {
-            ctx.render(*width, *height).await?;
-        }
-
         // Quit
         Event::Key(KeyEvent {
             code: KeyCode::Enter,
@@ -76,6 +76,31 @@ pub async fn default(event: &Event, ctx: &mut Json) -> anyhow::Result<Signal> {
             state: KeyEventState::NONE,
         }) => {
             ctx.json.document.toggle();
+        }
+
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }) => {
+            let renderer = ctx.renderer.clone();
+            if let Some(position) = renderer
+                .as_ref()
+                .and_then(|renderer| {
+                    renderer.hit_test(ScreenPosition {
+                        row: *row,
+                        column: *column,
+                    })
+                })
+                .filter(|position| position.index == Index::Json)
+            {
+                if let Some(JsonHit::Toggle { row_index }) =
+                    ctx.json.hit_at(position.content_position())
+                {
+                    ctx.json.document.toggle_at(row_index);
+                }
+            }
         }
 
         _ => (),

--- a/promkit/src/preset/listbox.rs
+++ b/promkit/src/preset/listbox.rs
@@ -5,7 +5,6 @@ use std::fmt::Display;
 use crate::{
     core::{
         crossterm::{
-            self,
             event::Event,
             style::{Attribute, Attributes, Color, ContentStyle},
         },
@@ -23,7 +22,7 @@ use crate::{
 pub mod evaluate;
 
 /// Represents the indices of various components in the listbox preset.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Index {
     Title = 0,
     Listbox = 1,
@@ -44,15 +43,11 @@ pub struct Listbox {
 #[async_trait::async_trait]
 impl crate::Prompt for Listbox {
     async fn initialize(&mut self) -> anyhow::Result<()> {
-        let size = crossterm::terminal::size()?;
         self.renderer = Some(SharedRenderer::new(
             Renderer::try_new_with_graphemes(
                 [
-                    (Index::Title, self.title.create_graphemes(size.0, size.1)),
-                    (
-                        Index::Listbox,
-                        self.listbox.create_graphemes(size.0, size.1),
-                    ),
+                    (Index::Title, self.title.create_graphemes()),
+                    (Index::Listbox, self.listbox.create_graphemes()),
                 ],
                 true,
             )
@@ -63,8 +58,7 @@ impl crate::Prompt for Listbox {
 
     async fn evaluate(&mut self, event: &Event) -> anyhow::Result<Signal> {
         let ret = (self.evaluator)(event, self).await;
-        let size = crossterm::terminal::size()?;
-        self.render(size.0, size.1).await?;
+        self.render().await?;
         ret
     }
 
@@ -155,13 +149,13 @@ impl Listbox {
     }
 
     /// Render the prompt with the specified width and height.
-    async fn render(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+    async fn render(&mut self) -> anyhow::Result<()> {
         match self.renderer.as_ref() {
             Some(renderer) => {
                 renderer
                     .update([
-                        (Index::Title, self.title.create_graphemes(width, height)),
-                        (Index::Listbox, self.listbox.create_graphemes(width, height)),
+                        (Index::Title, self.title.create_graphemes()),
+                        (Index::Listbox, self.listbox.create_graphemes()),
                     ])
                     .render()
                     .await

--- a/promkit/src/preset/listbox/evaluate.rs
+++ b/promkit/src/preset/listbox/evaluate.rs
@@ -1,9 +1,13 @@
 use crate::{
-    core::crossterm::event::{
-        Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent,
-        MouseEventKind,
+    core::{
+        crossterm::event::{
+            Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+            MouseEvent, MouseEventKind,
+        },
+        ScreenPosition,
     },
-    preset::listbox::Listbox,
+    preset::listbox::{Index, Listbox},
+    widgets::listbox::ListboxHit,
     Signal,
 };
 
@@ -15,6 +19,7 @@ use crate::{
 /// | <kbd>Ctrl + C</kbd>    | Interrupt the current operation
 /// | <kbd>↑</kbd>           | Move the selection up
 /// | <kbd>↓</kbd>           | Move the selection down
+/// | Left click             | Move the selection to the clicked item
 pub async fn default(event: &Event, ctx: &mut Listbox) -> anyhow::Result<Signal> {
     match event {
         // Quit
@@ -60,6 +65,31 @@ pub async fn default(event: &Event, ctx: &mut Listbox) -> anyhow::Result<Signal>
             modifiers: KeyModifiers::NONE,
         }) => {
             ctx.listbox.listbox.forward();
+        }
+
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }) => {
+            let renderer = ctx.renderer.clone();
+            if let Some(position) = renderer
+                .as_ref()
+                .and_then(|renderer| {
+                    renderer.hit_test(ScreenPosition {
+                        row: *row,
+                        column: *column,
+                    })
+                })
+                .filter(|position| position.index == Index::Listbox)
+            {
+                if let Some(ListboxHit::Select { index }) =
+                    ctx.listbox.hit_at(position.content_position())
+                {
+                    ctx.listbox.listbox.move_to(index);
+                }
+            }
         }
 
         _ => (),

--- a/promkit/src/preset/listbox/evaluate.rs
+++ b/promkit/src/preset/listbox/evaluate.rs
@@ -17,11 +17,6 @@ use crate::{
 /// | <kbd>↓</kbd>           | Move the selection down
 pub async fn default(event: &Event, ctx: &mut Listbox) -> anyhow::Result<Signal> {
     match event {
-        // Render for refreshing prompt on resize.
-        Event::Resize(width, height) => {
-            ctx.render(*width, *height).await?;
-        }
-
         // Quit
         Event::Key(KeyEvent {
             code: KeyCode::Enter,

--- a/promkit/src/preset/query_selector.rs
+++ b/promkit/src/preset/query_selector.rs
@@ -5,7 +5,6 @@ use std::fmt::Display;
 use crate::{
     core::{
         crossterm::{
-            self,
             event::Event,
             style::{Attribute, Attributes, Color, ContentStyle},
         },
@@ -24,7 +23,7 @@ use crate::{
 pub mod evaluate;
 
 /// Represents the indices of various components in the query selector preset.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Index {
     Title = 0,
     Readline = 1,
@@ -59,16 +58,12 @@ pub struct QuerySelector {
 #[async_trait::async_trait]
 impl crate::Prompt for QuerySelector {
     async fn initialize(&mut self) -> anyhow::Result<()> {
-        let size = crossterm::terminal::size()?;
         self.renderer = Some(SharedRenderer::new(
             Renderer::try_new_with_graphemes(
                 [
-                    (Index::Title, self.title.create_graphemes(size.0, size.1)),
-                    (
-                        Index::Readline,
-                        self.readline.create_graphemes(size.0, size.1),
-                    ),
-                    (Index::List, self.list.create_graphemes(size.0, size.1)),
+                    (Index::Title, self.title.create_graphemes()),
+                    (Index::Readline, self.readline.create_graphemes()),
+                    (Index::List, self.list.create_graphemes()),
                 ],
                 true,
             )
@@ -100,8 +95,7 @@ impl crate::Prompt for QuerySelector {
         }
 
         // Update the renderer with the new state of the components.
-        let size = crossterm::terminal::size()?;
-        self.render(size.0, size.1).await?;
+        self.render().await?;
 
         ret
     }
@@ -259,17 +253,14 @@ impl QuerySelector {
     }
 
     /// Render the prompt with the specified width and height.
-    async fn render(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+    async fn render(&mut self) -> anyhow::Result<()> {
         match self.renderer.as_ref() {
             Some(renderer) => {
                 renderer
                     .update([
-                        (Index::Title, self.title.create_graphemes(width, height)),
-                        (
-                            Index::Readline,
-                            self.readline.create_graphemes(width, height),
-                        ),
-                        (Index::List, self.list.create_graphemes(width, height)),
+                        (Index::Title, self.title.create_graphemes()),
+                        (Index::Readline, self.readline.create_graphemes()),
+                        (Index::List, self.list.create_graphemes()),
                     ])
                     .render()
                     .await

--- a/promkit/src/preset/query_selector/evaluate.rs
+++ b/promkit/src/preset/query_selector/evaluate.rs
@@ -7,11 +7,6 @@ use crate::{
 
 pub async fn default(event: &Event, ctx: &mut QuerySelector) -> anyhow::Result<Signal> {
     match event {
-        // Render for refreshing prompt on resize.
-        Event::Resize(width, height) => {
-            ctx.render(*width, *height).await?;
-        }
-
         // Quit
         Event::Key(KeyEvent {
             code: KeyCode::Enter,

--- a/promkit/src/preset/query_selector/evaluate.rs
+++ b/promkit/src/preset/query_selector/evaluate.rs
@@ -1,7 +1,16 @@
 use crate::{
-    core::crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers},
-    preset::query_selector::QuerySelector,
-    widgets::text_editor,
+    core::{
+        crossterm::event::{
+            Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+            MouseEvent, MouseEventKind,
+        },
+        ScreenPosition,
+    },
+    preset::query_selector::{Index, QuerySelector},
+    widgets::{
+        listbox::ListboxHit,
+        text_editor::{self, TextEditorHit},
+    },
     Signal,
 };
 
@@ -82,6 +91,39 @@ pub async fn default(event: &Event, ctx: &mut QuerySelector) -> anyhow::Result<S
             state: KeyEventState::NONE,
         }) => {
             ctx.list.listbox.forward();
+        }
+
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }) => {
+            let renderer = ctx.renderer.clone();
+            if let Some(position) = renderer.as_ref().and_then(|renderer| {
+                renderer.hit_test(ScreenPosition {
+                    row: *row,
+                    column: *column,
+                })
+            }) {
+                match position.index {
+                    Index::Readline => {
+                        if let Some(TextEditorHit::Cursor { index }) =
+                            ctx.readline.hit_at(position.content_position())
+                        {
+                            ctx.readline.texteditor.move_to(index);
+                        }
+                    }
+                    Index::List => {
+                        if let Some(ListboxHit::Select { index }) =
+                            ctx.list.hit_at(position.content_position())
+                        {
+                            ctx.list.listbox.move_to(index);
+                        }
+                    }
+                    Index::Title => {}
+                }
+            }
         }
 
         // Input char.

--- a/promkit/src/preset/readline.rs
+++ b/promkit/src/preset/readline.rs
@@ -5,7 +5,6 @@ use std::collections::HashSet;
 use crate::{
     core::{
         crossterm::{
-            self,
             event::Event,
             style::{Attribute, Attributes, Color, ContentStyle},
         },
@@ -26,7 +25,7 @@ use crate::{
 pub mod evaluate;
 
 /// Represents the indices of various components in the readline preset.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Index {
     Title = 0,
     Readline = 1,
@@ -138,23 +137,13 @@ impl Default for Readline {
 #[async_trait::async_trait]
 impl crate::Prompt for Readline {
     async fn initialize(&mut self) -> anyhow::Result<()> {
-        let size = crossterm::terminal::size()?;
         self.renderer = Some(SharedRenderer::new(
             Renderer::try_new_with_graphemes(
                 [
-                    (Index::Title, self.title.create_graphemes(size.0, size.1)),
-                    (
-                        Index::Readline,
-                        self.readline.create_graphemes(size.0, size.1),
-                    ),
-                    (
-                        Index::Suggestion,
-                        self.suggestions.create_graphemes(size.0, size.1),
-                    ),
-                    (
-                        Index::ErrorMessage,
-                        self.error_message.create_graphemes(size.0, size.1),
-                    ),
+                    (Index::Title, self.title.create_graphemes()),
+                    (Index::Readline, self.readline.create_graphemes()),
+                    (Index::Suggestion, self.suggestions.create_graphemes()),
+                    (Index::ErrorMessage, self.error_message.create_graphemes()),
                 ],
                 true,
             )
@@ -165,8 +154,7 @@ impl crate::Prompt for Readline {
 
     async fn evaluate(&mut self, event: &Event) -> anyhow::Result<Signal> {
         let ret = (self.evaluator)(event, self).await;
-        let size = crossterm::terminal::size()?;
-        self.render(size.0, size.1).await?;
+        self.render().await?;
         ret
     }
 
@@ -272,24 +260,15 @@ impl Readline {
     }
 
     /// Render the prompt with the specified width and height.
-    async fn render(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+    async fn render(&mut self) -> anyhow::Result<()> {
         match self.renderer.as_ref() {
             Some(renderer) => {
                 renderer
                     .update([
-                        (Index::Title, self.title.create_graphemes(width, height)),
-                        (
-                            Index::Readline,
-                            self.readline.create_graphemes(width, height),
-                        ),
-                        (
-                            Index::Suggestion,
-                            self.suggestions.create_graphemes(width, height),
-                        ),
-                        (
-                            Index::ErrorMessage,
-                            self.error_message.create_graphemes(width, height),
-                        ),
+                        (Index::Title, self.title.create_graphemes()),
+                        (Index::Readline, self.readline.create_graphemes()),
+                        (Index::Suggestion, self.suggestions.create_graphemes()),
+                        (Index::ErrorMessage, self.error_message.create_graphemes()),
                     ])
                     .render()
                     .await

--- a/promkit/src/preset/readline/evaluate.rs
+++ b/promkit/src/preset/readline/evaluate.rs
@@ -12,34 +12,21 @@ use crate::{
 pub async fn default(event: &Event, ctx: &mut Readline) -> anyhow::Result<Signal> {
     // Handle the common events for both readline and suggestion modes.
     match event {
-        // Render for refreshing prompt on resize.
-        Event::Resize(width, height) => {
-            ctx.render(*width, *height).await?;
-        }
-
         // Quit
         Event::Key(KeyEvent {
             code: KeyCode::Char('c'),
             modifiers: KeyModifiers::CONTROL,
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
-        }) => return Err(anyhow::anyhow!("ctrl+c")),
+        }) => Err(anyhow::anyhow!("ctrl+c")),
 
-        _ => {
-            match ctx.focus {
-                Focus::Readline => {
-                    // Handle the readline input events.
-                    return readline(event, ctx).await;
-                }
-                Focus::Suggestion => {
-                    // Handle the suggestion input events.
-                    return suggestion(event, ctx).await;
-                }
-            }
-        }
+        _ => match ctx.focus {
+            // Handle the readline input events.
+            Focus::Readline => readline(event, ctx).await,
+            // Handle the suggestion input events.
+            Focus::Suggestion => suggestion(event, ctx).await,
+        },
     }
-
-    Ok(Signal::Continue)
 }
 
 /// Default key bindings for the text editor.

--- a/promkit/src/preset/readline/evaluate.rs
+++ b/promkit/src/preset/readline/evaluate.rs
@@ -1,11 +1,21 @@
-use promkit_widgets::{listbox::Listbox, text::Text, text_editor};
+use promkit_widgets::{
+    listbox::{Listbox, ListboxHit},
+    text::Text,
+    text_editor::{self, TextEditorHit},
+};
 
 use crate::{
-    core::crossterm::{
-        event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers},
-        style::ContentStyle,
+    core::{
+        crossterm::{
+            event::{
+                Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+                MouseEvent, MouseEventKind,
+            },
+            style::ContentStyle,
+        },
+        ScreenPosition,
     },
-    preset::readline::{Focus, Readline},
+    preset::readline::{Focus, Index, Readline},
     Signal,
 };
 
@@ -20,12 +30,56 @@ pub async fn default(event: &Event, ctx: &mut Readline) -> anyhow::Result<Signal
             state: KeyEventState::NONE,
         }) => Err(anyhow::anyhow!("ctrl+c")),
 
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }) => {
+            click(*column, *row, ctx);
+            Ok(Signal::Continue)
+        }
+
         _ => match ctx.focus {
             // Handle the readline input events.
             Focus::Readline => readline(event, ctx).await,
             // Handle the suggestion input events.
             Focus::Suggestion => suggestion(event, ctx).await,
         },
+    }
+}
+
+fn click(column: u16, row: u16, ctx: &mut Readline) {
+    let renderer = ctx.renderer.clone();
+    let Some(position) = renderer
+        .as_ref()
+        .and_then(|renderer| renderer.hit_test(ScreenPosition { row, column }))
+    else {
+        return;
+    };
+
+    match position.index {
+        Index::Readline => {
+            if let Some(TextEditorHit::Cursor { index }) =
+                ctx.readline.hit_at(position.content_position())
+            {
+                ctx.readline.texteditor.move_to(index);
+                ctx.suggestions.listbox = Listbox::from(Vec::<String>::new());
+                ctx.focus = Focus::Readline;
+            }
+        }
+        Index::Suggestion => {
+            if let Some(ListboxHit::Select { index }) =
+                ctx.suggestions.hit_at(position.content_position())
+            {
+                ctx.suggestions.listbox.move_to(index);
+                ctx.readline
+                    .texteditor
+                    .replace(&ctx.suggestions.listbox.get().to_string());
+                ctx.focus = Focus::Suggestion;
+            }
+        }
+        Index::Title | Index::ErrorMessage => {}
     }
 }
 
@@ -48,6 +102,7 @@ pub async fn default(event: &Event, ctx: &mut Readline) -> anyhow::Result<Signal
 /// | <kbd>Alt + F</kbd>     | Move the cursor to the next nearest character within set (default: whitespace)
 /// | <kbd>Ctrl + W</kbd>    | Erase to the previous nearest character within set (default: whitespace)
 /// | <kbd>Alt + D</kbd>     | Erase to the next nearest character within set (default: whitespace)
+/// | Left click             | Move the cursor or select the clicked suggestion
 pub async fn readline(event: &Event, ctx: &mut Readline) -> anyhow::Result<Signal> {
     match event {
         // Return the input text when the validation passes.

--- a/promkit/src/preset/text.rs
+++ b/promkit/src/preset/text.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     core::{
-        crossterm::{self, event::Event, style::ContentStyle},
+        crossterm::{event::Event, style::ContentStyle},
         render::{Renderer, SharedRenderer},
         Widget,
     },
@@ -14,7 +14,7 @@ use crate::{
 pub mod evaluate;
 
 /// Represents the indices of various components in the text preset.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Index {
     Text = 0,
 }
@@ -32,21 +32,16 @@ pub struct Text {
 #[async_trait::async_trait]
 impl crate::Prompt for Text {
     async fn initialize(&mut self) -> anyhow::Result<()> {
-        let size = crossterm::terminal::size()?;
         self.renderer = Some(SharedRenderer::new(
-            Renderer::try_new_with_graphemes(
-                [(Index::Text, self.text.create_graphemes(size.0, size.1))],
-                true,
-            )
-            .await?,
+            Renderer::try_new_with_graphemes([(Index::Text, self.text.create_graphemes())], true)
+                .await?,
         ));
         Ok(())
     }
 
     async fn evaluate(&mut self, event: &Event) -> anyhow::Result<Signal> {
         let ret = (self.evaluator)(event, self).await;
-        let size = crossterm::terminal::size()?;
-        self.render(size.0, size.1).await?;
+        self.render().await?;
         ret
     }
 
@@ -83,11 +78,11 @@ impl Text {
     }
 
     /// Render the prompt with the specified width and height.
-    async fn render(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+    async fn render(&mut self) -> anyhow::Result<()> {
         match self.renderer.as_ref() {
             Some(renderer) => {
                 renderer
-                    .update([(Index::Text, self.text.create_graphemes(width, height))])
+                    .update([(Index::Text, self.text.create_graphemes())])
                     .render()
                     .await
             }

--- a/promkit/src/preset/text/evaluate.rs
+++ b/promkit/src/preset/text/evaluate.rs
@@ -17,11 +17,6 @@ use crate::{
 /// | <kbd>↓</kbd>           | Move the selection down
 pub async fn default(event: &Event, ctx: &mut Text) -> anyhow::Result<Signal> {
     match event {
-        // Render for refreshing prompt on resize.
-        Event::Resize(width, height) => {
-            ctx.render(*width, *height).await?;
-        }
-
         // Quit
         Event::Key(KeyEvent {
             code: KeyCode::Enter,

--- a/promkit/src/preset/text/evaluate.rs
+++ b/promkit/src/preset/text/evaluate.rs
@@ -1,9 +1,13 @@
 use crate::{
-    core::crossterm::event::{
-        Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent,
-        MouseEventKind,
+    core::{
+        crossterm::event::{
+            Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+            MouseEvent, MouseEventKind,
+        },
+        ScreenPosition,
     },
-    preset::text::Text,
+    preset::text::{Index, Text},
+    widgets::text::TextHit,
     Signal,
 };
 
@@ -15,6 +19,7 @@ use crate::{
 /// | <kbd>Ctrl + C</kbd>    | Interrupt the current operation
 /// | <kbd>↑</kbd>           | Move the selection up
 /// | <kbd>↓</kbd>           | Move the selection down
+/// | Left click             | Move the selection to the clicked line
 pub async fn default(event: &Event, ctx: &mut Text) -> anyhow::Result<Signal> {
     match event {
         // Quit
@@ -60,6 +65,31 @@ pub async fn default(event: &Event, ctx: &mut Text) -> anyhow::Result<Signal> {
             modifiers: KeyModifiers::NONE,
         }) => {
             ctx.text.text.forward();
+        }
+
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }) => {
+            let renderer = ctx.renderer.clone();
+            if let Some(position) = renderer
+                .as_ref()
+                .and_then(|renderer| {
+                    renderer.hit_test(ScreenPosition {
+                        row: *row,
+                        column: *column,
+                    })
+                })
+                .filter(|position| position.index == Index::Text)
+            {
+                if let Some(TextHit::Select { index }) =
+                    ctx.text.hit_at(position.content_position())
+                {
+                    ctx.text.text.move_to(index);
+                }
+            }
         }
 
         _ => (),

--- a/promkit/src/preset/tree.rs
+++ b/promkit/src/preset/tree.rs
@@ -3,7 +3,6 @@
 use crate::{
     core::{
         crossterm::{
-            self,
             event::Event,
             style::{Attribute, Attributes, Color, ContentStyle},
         },
@@ -21,7 +20,7 @@ use crate::{
 pub mod evaluate;
 
 /// Represents the indices of various components in the tree preset.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Index {
     Title = 0,
     Tree = 1,
@@ -43,12 +42,11 @@ pub struct Tree {
 #[async_trait::async_trait]
 impl crate::Prompt for Tree {
     async fn initialize(&mut self) -> anyhow::Result<()> {
-        let size = crossterm::terminal::size()?;
         self.renderer = Some(SharedRenderer::new(
             Renderer::try_new_with_graphemes(
                 [
-                    (Index::Title, self.title.create_graphemes(size.0, size.1)),
-                    (Index::Tree, self.tree.create_graphemes(size.0, size.1)),
+                    (Index::Title, self.title.create_graphemes()),
+                    (Index::Tree, self.tree.create_graphemes()),
                 ],
                 true,
             )
@@ -59,8 +57,7 @@ impl crate::Prompt for Tree {
 
     async fn evaluate(&mut self, event: &Event) -> anyhow::Result<Signal> {
         let ret = (self.evaluator)(event, self).await;
-        let size = crossterm::terminal::size()?;
-        self.render(size.0, size.1).await?;
+        self.render().await?;
         ret
     }
 
@@ -159,13 +156,13 @@ impl Tree {
     }
 
     /// Render the prompt with the specified width and height.
-    async fn render(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+    async fn render(&mut self) -> anyhow::Result<()> {
         match self.renderer.as_ref() {
             Some(renderer) => {
                 renderer
                     .update([
-                        (Index::Title, self.title.create_graphemes(width, height)),
-                        (Index::Tree, self.tree.create_graphemes(width, height)),
+                        (Index::Title, self.title.create_graphemes()),
+                        (Index::Tree, self.tree.create_graphemes()),
                     ])
                     .render()
                     .await

--- a/promkit/src/preset/tree/evaluate.rs
+++ b/promkit/src/preset/tree/evaluate.rs
@@ -1,9 +1,13 @@
 use crate::{
-    core::crossterm::event::{
-        Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent,
-        MouseEventKind,
+    core::{
+        crossterm::event::{
+            Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+            MouseEvent, MouseEventKind,
+        },
+        ScreenPosition,
     },
-    preset::tree::Tree,
+    preset::tree::{Index, Tree},
+    widgets::structured::tree::TreeHit,
     Signal,
 };
 
@@ -16,6 +20,7 @@ use crate::{
 /// | <kbd>↑</kbd>           | Move the selection up
 /// | <kbd>↓</kbd>           | Move the selection down
 /// | <kbd>Space</kbd>       | Toggle fold/unfold at the current node
+/// | Left click             | Move to and toggle the clicked node
 pub async fn default(event: &Event, ctx: &mut Tree) -> anyhow::Result<Signal> {
     match event {
         // Quit
@@ -75,6 +80,31 @@ pub async fn default(event: &Event, ctx: &mut Tree) -> anyhow::Result<Signal> {
             state: KeyEventState::NONE,
         }) => {
             ctx.tree.document.toggle();
+        }
+
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }) => {
+            let renderer = ctx.renderer.clone();
+            if let Some(position) = renderer
+                .as_ref()
+                .and_then(|renderer| {
+                    renderer.hit_test(ScreenPosition {
+                        row: *row,
+                        column: *column,
+                    })
+                })
+                .filter(|position| position.index == Index::Tree)
+            {
+                if let Some(TreeHit::Toggle { row_index }) =
+                    ctx.tree.hit_at(position.content_position())
+                {
+                    ctx.tree.document.toggle_at(row_index);
+                }
+            }
         }
 
         _ => (),

--- a/promkit/src/preset/tree/evaluate.rs
+++ b/promkit/src/preset/tree/evaluate.rs
@@ -18,11 +18,6 @@ use crate::{
 /// | <kbd>Space</kbd>       | Toggle fold/unfold at the current node
 pub async fn default(event: &Event, ctx: &mut Tree) -> anyhow::Result<Signal> {
     match event {
-        // Render for refreshing prompt on resize.
-        Event::Resize(width, height) => {
-            ctx.render(*width, *height).await?;
-        }
-
         // Quit
         Event::Key(KeyEvent {
             code: KeyCode::Enter,

--- a/promkit/src/preset/yaml.rs
+++ b/promkit/src/preset/yaml.rs
@@ -3,7 +3,6 @@
 use crate::{
     core::{
         crossterm::{
-            self,
             event::Event,
             style::{Attribute, Attributes, Color, ContentStyle},
         },
@@ -25,7 +24,7 @@ use crate::{
 pub mod evaluate;
 
 /// Represents the indices of various components in the YAML preset.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Index {
     Title = 0,
     Yaml = 1,
@@ -46,12 +45,11 @@ pub struct Yaml {
 #[async_trait::async_trait]
 impl crate::Prompt for Yaml {
     async fn initialize(&mut self) -> anyhow::Result<()> {
-        let size = crossterm::terminal::size()?;
         self.renderer = Some(SharedRenderer::new(
             Renderer::try_new_with_graphemes(
                 [
-                    (Index::Title, self.title.create_graphemes(size.0, size.1)),
-                    (Index::Yaml, self.yaml.create_graphemes(size.0, size.1)),
+                    (Index::Title, self.title.create_graphemes()),
+                    (Index::Yaml, self.yaml.create_graphemes()),
                 ],
                 true,
             )
@@ -62,8 +60,7 @@ impl crate::Prompt for Yaml {
 
     async fn evaluate(&mut self, event: &Event) -> anyhow::Result<Signal> {
         let ret = (self.evaluator)(event, self).await;
-        let size = crossterm::terminal::size()?;
-        self.render(size.0, size.1).await?;
+        self.render().await?;
         ret
     }
 
@@ -178,13 +175,13 @@ impl Yaml {
     }
 
     /// Render the prompt with the specified width and height.
-    async fn render(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+    async fn render(&mut self) -> anyhow::Result<()> {
         match self.renderer.as_ref() {
             Some(renderer) => {
                 renderer
                     .update([
-                        (Index::Title, self.title.create_graphemes(width, height)),
-                        (Index::Yaml, self.yaml.create_graphemes(width, height)),
+                        (Index::Title, self.title.create_graphemes()),
+                        (Index::Yaml, self.yaml.create_graphemes()),
                     ])
                     .render()
                     .await

--- a/promkit/src/preset/yaml/evaluate.rs
+++ b/promkit/src/preset/yaml/evaluate.rs
@@ -1,9 +1,13 @@
 use crate::{
-    core::crossterm::event::{
-        Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent,
-        MouseEventKind,
+    core::{
+        crossterm::event::{
+            Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+            MouseEvent, MouseEventKind,
+        },
+        ScreenPosition,
     },
-    preset::yaml::Yaml,
+    preset::yaml::{Index, Yaml},
+    widgets::yaml::YamlHit,
     Signal,
 };
 
@@ -16,13 +20,9 @@ use crate::{
 /// | <kbd>↑</kbd>           | Move the cursor up to the previous node
 /// | <kbd>↓</kbd>           | Move the cursor down to the next node
 /// | <kbd>Space</kbd>       | Toggle fold/unfold on the current node
+/// | Left click             | Toggle fold/unfold on the clicked node
 pub async fn default(event: &Event, ctx: &mut Yaml) -> anyhow::Result<Signal> {
     match event {
-        // Render for refreshing prompt on resize.
-        Event::Resize(width, height) => {
-            ctx.render(*width, *height).await?;
-        }
-
         // Quit
         Event::Key(KeyEvent {
             code: KeyCode::Enter,
@@ -76,6 +76,31 @@ pub async fn default(event: &Event, ctx: &mut Yaml) -> anyhow::Result<Signal> {
             state: KeyEventState::NONE,
         }) => {
             ctx.yaml.document.toggle();
+        }
+
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }) => {
+            let renderer = ctx.renderer.clone();
+            if let Some(position) = renderer
+                .as_ref()
+                .and_then(|renderer| {
+                    renderer.hit_test(ScreenPosition {
+                        row: *row,
+                        column: *column,
+                    })
+                })
+                .filter(|position| position.index == Index::Yaml)
+            {
+                if let Some(YamlHit::Toggle { row_index }) =
+                    ctx.yaml.hit_at(position.content_position())
+                {
+                    ctx.yaml.document.toggle_at(row_index);
+                }
+            }
         }
 
         _ => (),


### PR DESCRIPTION
## Summary

- Move terminal-dependent wrapping, truncation, viewport allocation, and scrolling from widgets into `promkit-core::Renderer`
- Add explicit content, visual, and screen coordinate types
- Preserve the latest rendered layout for screen-to-widget hit testing and widget-to-screen position mapping
- Enable mouse capture while a prompt is running
- Add semantic click handling across interactive widgets and presets

## Mouse interactions

- JSON / YAML / Tree: toggle the clicked node
- Checkbox: focus and toggle the clicked item
- Listbox: select the clicked item
- Text: select the clicked line
- Readline / Password / Confirm: move the text cursor to the clicked position
- Readline suggestions: select the clicked suggestion
- QuerySelector: position the input cursor or select a list item
- Form: focus the clicked field and position its text cursor

Text cursor hit testing accounts for prefixes, wrapped content, wide characters, masked input, and clicks beyond the rendered input.

## Widget layout changes

`Widget::create_graphemes` now returns width-independent `CreatedGraphemes` containing:

- complete styled content
- layout preferences such as maximum height and overflow mode
- an optional logical cursor position

The renderer uses this information to:

- wrap or truncate content for the current terminal width
- allocate vertical space between widgets
- maintain keyed viewports
- scroll only when the logical cursor leaves its viewport
- retain the rendered layout for subsequent hit testing

## Breaking changes

- `Widget::create_graphemes(width, height)` was replaced with `Widget::create_graphemes()`
- Widget implementations now return `CreatedGraphemes` instead of render-ready `StyledGraphemes`
- Terminal-dependent layout and clipping now belong to `Renderer`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo test --workspace --all-features -- --nocapture --format pretty`
- `cargo doc -p promkit-core -p promkit-widgets -p promkit --all-features --no-deps`