### PR TITLE
feat(widgets): add stable structured line numbers

### DIFF
--- a/examples/json/src/json.rs
+++ b/examples/json/src/json.rs
@@ -81,6 +81,7 @@ async fn main() -> anyhow::Result<()> {
     let document = Document::new(values.iter());
     Json::new(document)
         .title("JSON Viewer")
+        .show_line_numbers(true)
         .overflow_mode(OverflowMode::Wrap)
         .run()
         .await

--- a/examples/tree/src/tree.rs
+++ b/examples/tree/src/tree.rs
@@ -8,6 +8,7 @@ async fn main() -> anyhow::Result<()> {
     let document = Document::from_path(&root)?;
     let ret = Tree::new(document)
         .title("Select a directory or file")
+        .show_line_numbers(true)
         .tree_lines(10)
         .run()
         .await?;

--- a/examples/yaml/src/yaml.rs
+++ b/examples/yaml/src/yaml.rs
@@ -81,6 +81,7 @@ async fn main() -> anyhow::Result<()> {
     let document = Document::new(values.iter());
     Yaml::new(document)
         .title("YAML Viewer")
+        .show_line_numbers(true)
         .overflow_mode(OverflowMode::Wrap)
         .run()
         .await

--- a/promkit-widgets/README.md
+++ b/promkit-widgets/README.md
@@ -62,3 +62,15 @@ cargo bench -p promkit-widgets --bench structured --features json,yaml
 
 This benchmark exercises the `promkit-widgets` projection layer. It does not
 measure `promkit-core::Renderer`, terminal layout, or terminal I/O.
+
+## Structured line numbers
+
+The `json`, `yaml`, and `tree` widgets can display stable, one-based line
+numbers by enabling `show_line_numbers` in their `Config`. Numbers refer to the
+fully expanded structure, so collapsing a node leaves gaps for its hidden rows.
+
+The corresponding `promkit` presets expose `.show_line_numbers(bool)`:
+
+```rust
+let preset = Json::new(document).show_line_numbers(true);
+```

--- a/promkit-widgets/src/structured/json.rs
+++ b/promkit-widgets/src/structured/json.rs
@@ -29,7 +29,11 @@ impl Widget for State {
     fn create_graphemes(&self) -> CreatedGraphemes {
         let rows = self.document.visible_rows();
         let active_row = self.document.visible_position();
-        self.create_graphemes_from_rows(&rows, active_row)
+        let line_numbers = self
+            .config
+            .show_line_numbers
+            .then(|| self.document.visible_line_numbers());
+        self.create_graphemes_from_rows(&rows, active_row, line_numbers)
     }
 
     fn create_graphemes_in_viewport(&self, _width: u16, height: u16) -> CreatedGraphemes {
@@ -38,7 +42,11 @@ impl Widget for State {
             .lines
             .map_or(height as usize, |lines| lines.min(height as usize));
         let rows = self.document.extract_rows_from_current(height);
-        self.create_graphemes_from_rows(&rows, 0)
+        let line_numbers = self
+            .config
+            .show_line_numbers
+            .then(|| self.document.line_numbers_from_current(height));
+        self.create_graphemes_from_rows(&rows, 0, line_numbers)
     }
 }
 
@@ -47,8 +55,13 @@ impl State {
         &self,
         rows: &[jsonz::Row],
         active_row: usize,
+        line_numbers: Option<Vec<usize>>,
     ) -> CreatedGraphemes {
-        let formatted_rows = self.config.render_content_rows(rows, active_row);
+        let mut formatted_rows = self.config.render_content_rows(rows, active_row);
+        if let Some(line_numbers) = line_numbers {
+            formatted_rows =
+                super::with_line_numbers(formatted_rows, line_numbers, self.document.line_count());
+        }
 
         CreatedGraphemes {
             graphemes: StyledGraphemes::from_lines(formatted_rows),
@@ -145,5 +158,60 @@ mod tests {
 
         let projected = state.create_graphemes_in_viewport(80, 20);
         assert_eq!(projected.graphemes.logical_lines().len(), 1);
+    }
+
+    #[test]
+    fn preserves_expanded_line_numbers_after_toggle() {
+        let value = serde_json::json!({
+            "first": {
+                "nested": 1
+            },
+            "last": 2
+        });
+        let mut state = State {
+            document: Document::new([&value]),
+            config: Config {
+                indent: 2,
+                show_line_numbers: true,
+                ..Default::default()
+            },
+        };
+
+        assert_eq!(
+            state.document.visible_line_numbers(),
+            vec![1, 2, 3, 4, 5, 6]
+        );
+
+        state.document.down();
+        state.document.toggle();
+
+        assert_eq!(state.document.visible_line_numbers(), vec![1, 2, 5, 6]);
+        assert_eq!(
+            state.create_graphemes().graphemes.to_string(),
+            "1 {\n2   \"first\": {…},\n5   \"last\": 2\n6 }"
+        );
+    }
+
+    #[test]
+    fn viewport_projection_uses_stable_line_numbers_from_cursor() {
+        let value = serde_json::json!({"first": 1, "second": 2, "third": 3});
+        let mut state = State {
+            document: Document::new([&value]),
+            config: Config {
+                show_line_numbers: true,
+                ..Default::default()
+            },
+        };
+
+        state.document.down();
+        state.document.down();
+
+        assert_eq!(
+            state
+                .create_graphemes_in_viewport(80, 2)
+                .graphemes
+                .to_string(),
+            "3 \"second\": 2,\n4 \"third\": 3"
+        );
     }
 }

--- a/promkit-widgets/src/structured/json/config.rs
+++ b/promkit-widgets/src/structured/json/config.rs
@@ -90,6 +90,8 @@ pub struct Config {
     pub overflow_mode: OverflowMode,
     /// Number of lines available for rendering.
     pub lines: Option<usize>,
+    /// Whether to display stable one-based line numbers to the left of the content.
+    pub show_line_numbers: bool,
 }
 
 impl Default for Config {
@@ -107,6 +109,7 @@ impl Default for Config {
             indent: Default::default(),
             overflow_mode: OverflowMode::default(),
             lines: Default::default(),
+            show_line_numbers: false,
         }
     }
 }
@@ -329,6 +332,7 @@ mod tests {
             obj.remove("inactive_item_attribute");
             obj.remove("overflow_mode");
             obj.remove("lines");
+            obj.remove("show_line_numbers");
 
             let formatter: Config = serde_json::from_value(value).unwrap();
 
@@ -337,6 +341,7 @@ mod tests {
             assert_eq!(formatter.inactive_item_attribute, Attribute::NoBold);
             assert_eq!(formatter.overflow_mode, OverflowMode::Truncate);
             assert_eq!(formatter.lines, None);
+            assert!(!formatter.show_line_numbers);
         }
 
         #[test]
@@ -344,6 +349,7 @@ mod tests {
             let input = r#"
                 indent = 4
                 lines = 7
+                show_line_numbers = true
                 curly_brackets_style = "attr=bold"
                 square_brackets_style = "attr=bold"
                 key_style = "fg=cyan"
@@ -360,6 +366,7 @@ mod tests {
 
             assert_eq!(formatter.indent, 4);
             assert_eq!(formatter.lines, Some(7));
+            assert!(formatter.show_line_numbers);
             assert_eq!(
                 formatter.curly_brackets_style.attributes,
                 Attributes::from(Attribute::Bold),

--- a/promkit-widgets/src/structured/json/document.rs
+++ b/promkit-widgets/src/structured/json/document.rs
@@ -32,6 +32,38 @@ impl Document {
         self.rows.extract(self.rows.head(), usize::MAX)
     }
 
+    /// Returns stable one-based line numbers for the currently visible rows.
+    pub(super) fn visible_line_numbers(&self) -> Vec<usize> {
+        self.line_numbers_from(self.rows.head(), usize::MAX)
+    }
+
+    /// Returns stable one-based line numbers for rows projected from the cursor.
+    pub(super) fn line_numbers_from_current(&self, n: usize) -> Vec<usize> {
+        self.line_numbers_from(self.position, n)
+    }
+
+    /// Returns the number of rows in the fully expanded document.
+    pub(super) fn line_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    fn line_numbers_from(&self, mut index: usize, n: usize) -> Vec<usize> {
+        if self.rows.is_empty() || n == 0 {
+            return Vec::new();
+        }
+
+        let mut line_numbers = Vec::new();
+        for _ in 0..n {
+            line_numbers.push(index + 1);
+            let next = self.rows.down(index);
+            if next == index {
+                break;
+            }
+            index = next;
+        }
+        line_numbers
+    }
+
     /// Returns the selected row's index in the visible row sequence.
     pub fn visible_position(&self) -> usize {
         visible_position(&self.rows, self.position)

--- a/promkit-widgets/src/structured/mod.rs
+++ b/promkit-widgets/src/structured/mod.rs
@@ -10,6 +10,30 @@ pub mod yaml;
 #[cfg_attr(docsrs, doc(cfg(feature = "tree")))]
 pub mod tree;
 
+use promkit_core::grapheme::StyledGraphemes;
+
+fn with_line_numbers(
+    lines: Vec<StyledGraphemes>,
+    line_numbers: Vec<usize>,
+    line_count: usize,
+) -> Vec<StyledGraphemes> {
+    debug_assert_eq!(lines.len(), line_numbers.len());
+    let width = line_count.max(1).to_string().len();
+
+    line_numbers
+        .into_iter()
+        .zip(lines)
+        .map(|(line_number, line)| {
+            [
+                StyledGraphemes::from(format!("{line_number:>width$} ")),
+                line,
+            ]
+            .into_iter()
+            .collect()
+        })
+        .collect()
+}
+
 /// Container type of structured widget.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ContainerType {

--- a/promkit-widgets/src/structured/tree.rs
+++ b/promkit-widgets/src/structured/tree.rs
@@ -29,29 +29,40 @@ impl Widget for State {
 
         let rows = self.document.visible_rows();
         let active_row = self.document.visible_position();
-        let lines = rows.iter().enumerate().map(|(offset, row)| {
-            if offset == active_row {
-                StyledGraphemes::from_str(
-                    format!(
-                        "{}{}{}",
-                        symbol(row),
-                        " ".repeat(row.depth * self.config.indent),
-                        row.id,
-                    ),
-                    self.config.active_item_style,
-                )
-            } else {
-                StyledGraphemes::from_str(
-                    format!(
-                        "{}{}{}",
-                        " ".repeat(StyledGraphemes::from(symbol(row)).widths()),
-                        " ".repeat(row.depth * self.config.indent),
-                        row.id,
-                    ),
-                    self.config.inactive_item_style,
-                )
-            }
-        });
+        let mut lines = rows
+            .iter()
+            .enumerate()
+            .map(|(offset, row)| {
+                if offset == active_row {
+                    StyledGraphemes::from_str(
+                        format!(
+                            "{}{}{}",
+                            symbol(row),
+                            " ".repeat(row.depth * self.config.indent),
+                            row.id,
+                        ),
+                        self.config.active_item_style,
+                    )
+                } else {
+                    StyledGraphemes::from_str(
+                        format!(
+                            "{}{}{}",
+                            " ".repeat(StyledGraphemes::from(symbol(row)).widths()),
+                            " ".repeat(row.depth * self.config.indent),
+                            row.id,
+                        ),
+                        self.config.inactive_item_style,
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+        if self.config.show_line_numbers {
+            lines = super::with_line_numbers(
+                lines,
+                self.document.visible_line_numbers(),
+                self.document.line_count(),
+            );
+        }
 
         CreatedGraphemes {
             graphemes: StyledGraphemes::from_lines(lines),
@@ -116,5 +127,48 @@ mod tests {
             Some(TreeHit::Toggle { row_index: 1 })
         );
         assert_eq!(state.hit_at(ContentPosition { row: 2, column: 0 }), None);
+    }
+
+    #[test]
+    fn preserves_expanded_line_numbers_after_toggle() {
+        let mut state = State {
+            document: Document::new(vec![
+                Row {
+                    id: "root".into(),
+                    path: vec!["root".into()],
+                    depth: 0,
+                    has_children: true,
+                    collapsed: false,
+                },
+                Row {
+                    id: "child".into(),
+                    path: vec!["root".into(), "child".into()],
+                    depth: 1,
+                    has_children: false,
+                    collapsed: false,
+                },
+                Row {
+                    id: "sibling".into(),
+                    path: vec!["sibling".into()],
+                    depth: 0,
+                    has_children: false,
+                    collapsed: false,
+                },
+            ]),
+            config: Config {
+                show_line_numbers: true,
+                ..Default::default()
+            },
+        };
+
+        assert_eq!(state.document.visible_line_numbers(), vec![1, 2, 3]);
+
+        state.document.toggle();
+
+        assert_eq!(state.document.visible_line_numbers(), vec![1, 3]);
+        let rendered = state.create_graphemes().graphemes.to_string();
+        assert!(rendered.starts_with("1 "));
+        assert!(rendered.contains("\n3 "));
+        assert!(!rendered.contains("\n2 "));
     }
 }

--- a/promkit-widgets/src/structured/tree/config.rs
+++ b/promkit-widgets/src/structured/tree/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub inactive_item_style: ContentStyle,
     pub indent: usize,
     pub lines: Option<usize>,
+    /// Whether to display stable one-based line numbers to the left of the content.
+    pub show_line_numbers: bool,
 }
 
 impl Default for Config {
@@ -32,6 +34,7 @@ impl Default for Config {
             inactive_item_style: ContentStyle::default(),
             indent: 2,
             lines: None,
+            show_line_numbers: false,
         }
     }
 }
@@ -53,6 +56,7 @@ active_item_style = "fg=cyan,attr=bold"
 inactive_item_style = "fg=grey"
 indent = 4
 lines = 9
+show_line_numbers = true
 "#;
             let formatter: Config = toml::from_str(input).unwrap();
 
@@ -69,6 +73,7 @@ lines = 9
             );
             assert_eq!(formatter.indent, 4);
             assert_eq!(formatter.lines, Some(9));
+            assert!(formatter.show_line_numbers);
         }
     }
 }

--- a/promkit-widgets/src/structured/tree/document.rs
+++ b/promkit-widgets/src/structured/tree/document.rs
@@ -43,6 +43,30 @@ impl Document {
         self.rows.extract(self.rows.head(), usize::MAX)
     }
 
+    /// Returns stable one-based line numbers for the currently visible rows.
+    pub(super) fn visible_line_numbers(&self) -> Vec<usize> {
+        if self.rows.is_empty() {
+            return Vec::new();
+        }
+
+        let mut line_numbers = Vec::new();
+        let mut index = self.rows.head();
+        loop {
+            line_numbers.push(index + 1);
+            let next = self.rows.down(index);
+            if next == index {
+                break;
+            }
+            index = next;
+        }
+        line_numbers
+    }
+
+    /// Returns the number of rows in the fully expanded tree.
+    pub(super) fn line_count(&self) -> usize {
+        self.rows.len()
+    }
+
     /// Returns the selected row's index in the visible row sequence.
     pub fn visible_position(&self) -> usize {
         visible_position(&self.rows, self.position)

--- a/promkit-widgets/src/structured/yaml.rs
+++ b/promkit-widgets/src/structured/yaml.rs
@@ -22,7 +22,11 @@ impl Widget for State {
     fn create_graphemes(&self) -> CreatedGraphemes {
         let rows = self.document.visible_rows();
         let active_row = self.document.visible_position();
-        self.create_graphemes_from_rows(&rows, active_row)
+        let line_numbers = self
+            .config
+            .show_line_numbers
+            .then(|| self.document.visible_line_numbers());
+        self.create_graphemes_from_rows(&rows, active_row, line_numbers)
     }
 
     fn create_graphemes_in_viewport(&self, _width: u16, height: u16) -> CreatedGraphemes {
@@ -31,7 +35,11 @@ impl Widget for State {
             .lines
             .map_or(height as usize, |lines| lines.min(height as usize));
         let rows = self.document.extract_rows_from_current(height);
-        self.create_graphemes_from_rows(&rows, 0)
+        let line_numbers = self
+            .config
+            .show_line_numbers
+            .then(|| self.document.line_numbers_from_current(height));
+        self.create_graphemes_from_rows(&rows, 0, line_numbers)
     }
 }
 
@@ -40,8 +48,13 @@ impl State {
         &self,
         rows: &[yamlz::Row],
         active_row: usize,
+        line_numbers: Option<Vec<usize>>,
     ) -> CreatedGraphemes {
-        let formatted_rows = self.config.render_content_rows(rows, active_row);
+        let mut formatted_rows = self.config.render_content_rows(rows, active_row);
+        if let Some(line_numbers) = line_numbers {
+            formatted_rows =
+                super::with_line_numbers(formatted_rows, line_numbers, self.document.line_count());
+        }
 
         CreatedGraphemes {
             graphemes: StyledGraphemes::from_lines(formatted_rows),
@@ -157,5 +170,49 @@ mod tests {
 
         let projected = state.create_graphemes_in_viewport(80, 20);
         assert_eq!(projected.graphemes.logical_lines().len(), 1);
+    }
+
+    #[test]
+    fn preserves_expanded_line_numbers_after_toggle() {
+        let value = serde_yaml::from_str("first:\n  nested: one\nlast: two\n").unwrap();
+        let mut state = State {
+            document: Document::new([&value]),
+            config: Config {
+                show_line_numbers: true,
+                ..Default::default()
+            },
+        };
+
+        assert_eq!(state.document.visible_line_numbers(), vec![1, 2, 3]);
+
+        state.document.toggle();
+
+        assert_eq!(state.document.visible_line_numbers(), vec![1, 3]);
+        assert_eq!(
+            state.create_graphemes().graphemes.to_string(),
+            "1 first: {…}\n3 last: two"
+        );
+    }
+
+    #[test]
+    fn viewport_projection_uses_stable_line_numbers_from_cursor() {
+        let value = serde_yaml::from_str("first: one\nsecond: two\nthird: three\n").unwrap();
+        let mut state = State {
+            document: Document::new([&value]),
+            config: Config {
+                show_line_numbers: true,
+                ..Default::default()
+            },
+        };
+
+        state.document.down();
+
+        assert_eq!(
+            state
+                .create_graphemes_in_viewport(80, 2)
+                .graphemes
+                .to_string(),
+            "2 second: two\n3 third: three"
+        );
     }
 }

--- a/promkit-widgets/src/structured/yaml.rs
+++ b/promkit-widgets/src/structured/yaml.rs
@@ -195,6 +195,27 @@ mod tests {
     }
 
     #[test]
+    fn collapsed_root_containers_use_the_first_visible_line_number() {
+        for (source, expected) in [
+            ("first: one\nsecond: two\n", "1 {…}"),
+            ("- first\n- second\n", "1 […]"),
+        ] {
+            let value = serde_yaml::from_str(source).unwrap();
+            let mut state = State {
+                document: Document::new([&value]),
+                config: Config {
+                    show_line_numbers: true,
+                    ..Default::default()
+                },
+            };
+
+            state.document.set_nodes_visibility(true);
+
+            assert_eq!(state.create_graphemes().graphemes.to_string(), expected);
+        }
+    }
+
+    #[test]
     fn viewport_projection_uses_stable_line_numbers_from_cursor() {
         let value = serde_yaml::from_str("first: one\nsecond: two\nthird: three\n").unwrap();
         let mut state = State {

--- a/promkit-widgets/src/structured/yaml/config.rs
+++ b/promkit-widgets/src/structured/yaml/config.rs
@@ -101,6 +101,8 @@ pub struct Config {
 
     /// Number of lines available for rendering.
     pub lines: Option<usize>,
+    /// Whether to display stable one-based line numbers to the left of the content.
+    pub show_line_numbers: bool,
 }
 
 impl Default for Config {
@@ -119,6 +121,7 @@ impl Default for Config {
             indent: 2,
             overflow_mode: OverflowMode::default(),
             lines: None,
+            show_line_numbers: false,
         }
     }
 }

--- a/promkit-widgets/src/structured/yaml/document.rs
+++ b/promkit-widgets/src/structured/yaml/document.rs
@@ -5,13 +5,37 @@ use crate::structured::yaml::yamlz::{self, Row, RowOperation};
 pub struct Document {
     rows: Vec<Row>,
     position: usize,
+    line_numbers: Vec<Option<usize>>,
+    line_count: usize,
 }
 
 impl Document {
     pub fn new<'a, I: IntoIterator<Item = &'a serde_yaml::Value>>(iter: I) -> Self {
         let rows = yamlz::create_rows(iter);
         let position = rows.head();
-        Self { rows, position }
+        let mut line_numbers = vec![None; rows.len()];
+        let mut line_count = 0;
+
+        if !rows.is_empty() {
+            let mut index = position;
+            loop {
+                line_count += 1;
+                line_numbers[index] = Some(line_count);
+
+                let next = rows.down(index);
+                if next == index {
+                    break;
+                }
+                index = next;
+            }
+        }
+
+        Self {
+            rows,
+            position,
+            line_numbers,
+            line_count,
+        }
     }
 }
 
@@ -29,6 +53,41 @@ impl Document {
     /// Returns all currently visible rows from the beginning of the document.
     pub fn visible_rows(&self) -> Vec<Row> {
         self.rows.extract(self.rows.head(), usize::MAX)
+    }
+
+    /// Returns stable one-based line numbers for the currently rendered rows.
+    pub(super) fn visible_line_numbers(&self) -> Vec<usize> {
+        self.line_numbers_from(self.rows.head(), usize::MAX)
+    }
+
+    /// Returns stable one-based line numbers for rows projected from the cursor.
+    pub(super) fn line_numbers_from_current(&self, n: usize) -> Vec<usize> {
+        self.line_numbers_from(self.position, n)
+    }
+
+    /// Returns the number of rows in the fully expanded YAML rendering.
+    pub(super) fn line_count(&self) -> usize {
+        self.line_count
+    }
+
+    fn line_numbers_from(&self, mut index: usize, n: usize) -> Vec<usize> {
+        if self.rows.is_empty() || n == 0 {
+            return Vec::new();
+        }
+
+        let mut line_numbers = Vec::new();
+        for _ in 0..n {
+            line_numbers.push(
+                self.line_numbers[index]
+                    .expect("every rendered YAML row must have a stable line number"),
+            );
+            let next = self.rows.down(index);
+            if next == index {
+                break;
+            }
+            index = next;
+        }
+        line_numbers
     }
 
     /// Returns the selected row's index in the rendered visible row sequence.

--- a/promkit-widgets/src/structured/yaml/document.rs
+++ b/promkit-widgets/src/structured/yaml/document.rs
@@ -77,10 +77,13 @@ impl Document {
 
         let mut line_numbers = Vec::new();
         for _ in 0..n {
-            line_numbers.push(
-                self.line_numbers[index]
-                    .expect("every rendered YAML row must have a stable line number"),
-            );
+            let stable_line_number = self.line_numbers[index].unwrap_or_else(|| {
+                self.line_numbers[index + 1..]
+                    .iter()
+                    .find_map(|number| *number)
+                    .expect("a collapsed YAML root must have a numbered visible descendant")
+            });
+            line_numbers.push(stable_line_number);
             let next = self.rows.down(index);
             if next == index {
                 break;

--- a/promkit/src/preset.rs
+++ b/promkit/src/preset.rs
@@ -52,3 +52,35 @@ pub type Evaluator<T> =
         event: &'a Event,
         ctx: &'a mut T,
     ) -> Pin<Box<dyn Future<Output = Result<Signal, anyhow::Error>> + Send + 'a>>;
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "json")]
+    #[test]
+    fn json_exposes_line_numbers() {
+        let value = crate::widgets::serde_json::json!({"first": 1});
+        let document = crate::widgets::json::Document::new([&value]);
+        let preset = super::json::Json::new(document).show_line_numbers(true);
+
+        assert!(preset.json.config.show_line_numbers);
+    }
+
+    #[cfg(feature = "tree")]
+    #[test]
+    fn tree_exposes_line_numbers() {
+        let document = crate::widgets::structured::tree::Document::new(Vec::new());
+        let preset = super::tree::Tree::new(document).show_line_numbers(true);
+
+        assert!(preset.tree.config.show_line_numbers);
+    }
+
+    #[cfg(feature = "yaml")]
+    #[test]
+    fn yaml_exposes_line_numbers() {
+        let value = crate::widgets::serde_yaml::from_str("first: one").unwrap();
+        let document = crate::widgets::yaml::Document::new([&value]);
+        let preset = super::yaml::Yaml::new(document).show_line_numbers(true);
+
+        assert!(preset.yaml.config.show_line_numbers);
+    }
+}

--- a/promkit/src/preset/json.rs
+++ b/promkit/src/preset/json.rs
@@ -121,6 +121,7 @@ impl Json {
                     indent: 2,
                     overflow_mode: OverflowMode::Truncate,
                     lines: Default::default(),
+                    show_line_numbers: false,
                 },
             },
         }
@@ -141,6 +142,12 @@ impl Json {
     /// Sets the number of lines to be used for rendering the JSON data.
     pub fn json_lines(mut self, lines: usize) -> Self {
         self.json.config.lines = Some(lines);
+        self
+    }
+
+    /// Sets whether stable one-based line numbers are displayed for JSON rows.
+    pub fn show_line_numbers(mut self, show: bool) -> Self {
+        self.json.config.show_line_numbers = show;
         self
     }
 

--- a/promkit/src/preset/tree.rs
+++ b/promkit/src/preset/tree.rs
@@ -96,6 +96,7 @@ impl Tree {
                     inactive_item_style: ContentStyle::default(),
                     indent: 2,
                     lines: Default::default(),
+                    show_line_numbers: false,
                 },
             },
         }
@@ -140,6 +141,12 @@ impl Tree {
     /// Sets the number of lines to be used for displaying the tree.
     pub fn tree_lines(mut self, lines: usize) -> Self {
         self.tree.config.lines = Some(lines);
+        self
+    }
+
+    /// Sets whether stable one-based line numbers are displayed for tree rows.
+    pub fn show_line_numbers(mut self, show: bool) -> Self {
+        self.tree.config.show_line_numbers = show;
         self
     }
 

--- a/promkit/src/preset/yaml.rs
+++ b/promkit/src/preset/yaml.rs
@@ -125,6 +125,7 @@ impl Yaml {
                     indent: 2,
                     overflow_mode: OverflowMode::Truncate,
                     lines: Default::default(),
+                    show_line_numbers: false,
                 },
             },
         }
@@ -145,6 +146,12 @@ impl Yaml {
     /// Sets the number of lines to be used for rendering the YAML data.
     pub fn yaml_lines(mut self, lines: usize) -> Self {
         self.yaml.config.lines = Some(lines);
+        self
+    }
+
+    /// Sets whether stable one-based line numbers are displayed for YAML rows.
+    pub fn show_line_numbers(mut self, show: bool) -> Self {
+        self.yaml.config.show_line_numbers = show;
         self
     }
 


### PR DESCRIPTION
## Summary

Add optional stable line numbers to the JSON, YAML, and tree structured widgets.

Line numbers are one-based and correspond to the fully expanded document. When a node is collapsed, hidden rows retain their original positions, so gaps remain in the displayed numbering.

## Changes

- Add `show_line_numbers` to the JSON, YAML, and tree widget configurations
- Add `.show_line_numbers(bool)` to the corresponding `promkit` presets
- Preserve stable numbering across collapsed nodes
- Support line numbers in viewport-bounded JSON and YAML rendering
- Keep line numbers disabled by default for backward compatibility
- Update JSON, YAML, and tree examples
- Add documentation and regression tests

## Example

```rust
Json::new(document)
    .show_line_numbers(true)
    .run()
    .await?;
```

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy`
- `cargo test -p promkit-widgets --all-features -- --nocapture --format pretty`
- `cargo test -- --nocapture --format pretty`