### PR TITLE
Add renderer layout benchmarks

### DIFF
--- a/Concept.md
+++ b/Concept.md
@@ -29,6 +29,9 @@ promkit is organized around three responsibilities with clear boundaries:
 3. **Rendering (`promkit-core`)**
    - [`Renderer<K>`](./promkit-core/src/render.rs) stores ordered
      `CreatedGraphemes` chunks.
+   - [`RendererLayout<K>`](./promkit-core/src/render/layout.rs) performs
+     terminal-size-dependent wrapping, pane allocation, cursor scrolling, and
+     viewport clipping without terminal I/O.
    - `update` / `remove` modify chunks by index key.
    - `render` wraps or truncates content, assigns vertical viewports, scrolls
      viewports to include logical cursors, and saves a keyed layout snapshot.

--- a/promkit-core/Cargo.toml
+++ b/promkit-core/Cargo.toml
@@ -14,3 +14,10 @@ crossbeam-skiplist = { workspace = true }
 crossterm = { workspace = true }
 tokio = { workspace = true }
 unicode-width = { workspace = true }
+
+[dev-dependencies]
+criterion = "0.8.2"
+
+[[bench]]
+name = "renderer_layout"
+harness = false

--- a/promkit-core/README.md
+++ b/promkit-core/README.md
@@ -1,1 +1,14 @@
 # promkit-core
+
+## Renderer layout benchmark
+
+The Criterion benchmark measures `Renderer` layout independently from terminal
+size queries and terminal I/O. It covers content size, wrapping and truncation,
+terminal width, pane count, and viewport movement:
+
+```bash
+cargo bench -p promkit-core --bench renderer_layout
+```
+
+Each iteration includes cloning the renderer inputs, matching the content
+snapshot cost paid by `Renderer::render`.

--- a/promkit-core/benches/renderer_layout.rs
+++ b/promkit-core/benches/renderer_layout.rs
@@ -1,0 +1,237 @@
+//! Benchmarks the renderer's terminal-size-dependent layout without terminal I/O.
+//!
+//! Each iteration clones the `CreatedGraphemes` inputs before laying them out,
+//! matching the snapshot cost paid by `Renderer::render`.
+
+use std::{hint::black_box, time::Duration};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use promkit_core::{
+    ContentPosition, CreatedGraphemes, WidgetLayout, WidthMode, grapheme::StyledGraphemes,
+    render::RendererLayout,
+};
+
+const TERMINAL_HEIGHT: u16 = 40;
+
+#[derive(Clone, Copy)]
+enum TextKind {
+    Ascii,
+    Unicode,
+}
+
+impl TextKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Ascii => "ascii",
+            Self::Unicode => "unicode",
+        }
+    }
+
+    fn line(self) -> &'static str {
+        match self {
+            Self::Ascii => {
+                "renderer layout keeps interactive terminal updates predictable across panes"
+            }
+            Self::Unicode => "端末レイアウトは全角文字とe\u{301}の表示幅も処理します",
+        }
+    }
+}
+
+fn renderer_layout(c: &mut Criterion) {
+    content_size(c);
+    terminal_width(c);
+    pane_count(c);
+    cursor_scrolling(c);
+}
+
+fn content_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("renderer_layout/content_size");
+
+    for size in [1024, 64 * 1024, 1024 * 1024] {
+        group.throughput(Throughput::Bytes(size as u64));
+
+        for kind in [TextKind::Ascii, TextKind::Unicode] {
+            for mode in [WidthMode::Wrap, WidthMode::Truncate] {
+                let contents = vec![(0usize, created_fixture(size, kind, mode, Cursor::Middle))];
+                let mut layout = RendererLayout::default();
+                let mode_name = match mode {
+                    WidthMode::Wrap => "wrap",
+                    WidthMode::Truncate => "truncate",
+                };
+
+                group.bench_with_input(
+                    BenchmarkId::new(format!("{}/{}", kind.name(), mode_name), size),
+                    &contents,
+                    |b, contents| {
+                        b.iter(|| {
+                            black_box(
+                                layout
+                                    .layout(black_box(contents.clone()), 80, TERMINAL_HEIGHT)
+                                    .unwrap(),
+                            )
+                        });
+                    },
+                );
+            }
+        }
+    }
+
+    group.finish();
+}
+
+fn terminal_width(c: &mut Criterion) {
+    let mut group = c.benchmark_group("renderer_layout/terminal_width");
+    let contents = vec![(
+        0usize,
+        created_fixture(
+            64 * 1024,
+            TextKind::Unicode,
+            WidthMode::Wrap,
+            Cursor::Middle,
+        ),
+    )];
+    group.throughput(Throughput::Bytes(64 * 1024));
+
+    for width in [20, 80, 240] {
+        let mut layout = RendererLayout::default();
+        group.bench_with_input(BenchmarkId::from_parameter(width), &width, |b, &width| {
+            b.iter(|| {
+                black_box(
+                    layout
+                        .layout(black_box(contents.clone()), width, TERMINAL_HEIGHT)
+                        .unwrap(),
+                )
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn pane_count(c: &mut Criterion) {
+    let mut group = c.benchmark_group("renderer_layout/pane_count");
+
+    for pane_count in [1usize, 10, 100] {
+        let contents = (0..pane_count)
+            .map(|index| {
+                (
+                    index,
+                    created_fixture(4 * 1024, TextKind::Ascii, WidthMode::Wrap, Cursor::Middle),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut layout = RendererLayout::default();
+        group.throughput(Throughput::Bytes((pane_count * 4 * 1024) as u64));
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(pane_count),
+            &contents,
+            |b, contents| {
+                b.iter(|| {
+                    black_box(
+                        layout
+                            .layout(
+                                black_box(contents.clone()),
+                                80,
+                                u16::try_from(pane_count.max(TERMINAL_HEIGHT as usize)).unwrap(),
+                            )
+                            .unwrap(),
+                    )
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn cursor_scrolling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("renderer_layout/cursor_scrolling");
+    let created = created_fixture(64 * 1024, TextKind::Ascii, WidthMode::Wrap, Cursor::Head);
+    let last_row = created
+        .graphemes
+        .to_string()
+        .lines()
+        .count()
+        .saturating_sub(1);
+    let mut layout = RendererLayout::default();
+    let mut at_tail = false;
+
+    group.throughput(Throughput::Bytes(64 * 1024));
+    group.bench_function("head_to_tail", |b| {
+        b.iter(|| {
+            let mut frame = created.clone();
+            frame.cursor = Some(ContentPosition {
+                row: if at_tail { last_row } else { 0 },
+                column: 0,
+            });
+            at_tail = !at_tail;
+
+            black_box(
+                layout
+                    .layout(black_box([(0usize, frame)]), 80, TERMINAL_HEIGHT)
+                    .unwrap(),
+            )
+        });
+    });
+
+    group.finish();
+}
+
+#[derive(Clone, Copy)]
+enum Cursor {
+    Head,
+    Middle,
+}
+
+fn created_fixture(
+    target_bytes: usize,
+    kind: TextKind,
+    width_mode: WidthMode,
+    cursor: Cursor,
+) -> CreatedGraphemes {
+    let text = text_fixture(target_bytes, kind);
+    let line_count = text.lines().count();
+    let cursor_row = match cursor {
+        Cursor::Head => 0,
+        Cursor::Middle => line_count / 2,
+    };
+
+    CreatedGraphemes {
+        graphemes: StyledGraphemes::from(text),
+        layout: WidgetLayout {
+            max_height: None,
+            width_mode,
+        },
+        cursor: Some(ContentPosition {
+            row: cursor_row,
+            column: 8,
+        }),
+    }
+}
+
+fn text_fixture(target_bytes: usize, kind: TextKind) -> String {
+    let line = kind.line();
+    let mut text = String::with_capacity(target_bytes + line.len() + 1);
+
+    while text.len() < target_bytes {
+        text.push_str(line);
+        text.push('\n');
+    }
+    let mut end = target_bytes.min(text.len());
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text.truncate(end);
+    text
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(2));
+    targets = renderer_layout
+}
+criterion_main!(benches);

--- a/promkit-core/src/render.rs
+++ b/promkit-core/src/render.rs
@@ -15,52 +15,28 @@
 //! positions against what was actually drawn rather than against newer,
 //! not-yet-rendered content.
 
-use std::{
-    collections::BTreeMap,
-    sync::{Arc, Mutex, RwLock},
-};
+use std::sync::{Arc, Mutex, RwLock};
 
 use crossbeam_skiplist::SkipMap;
 use tokio::sync::Mutex as AsyncMutex;
 
 use crate::{
-    grapheme::StyledGraphemes,
     terminal::Terminal,
-    widget::{
-        ContentPosition, CreatedGraphemes, ScreenPosition, VisualPosition, WidgetPosition,
-        WidgetViewport, WidthMode,
-    },
+    widget::{CreatedGraphemes, ScreenPosition, WidgetPosition},
 };
+
+mod layout;
+use layout::LayoutSnapshot;
+pub use layout::{PreparedLayout, RendererLayout};
 
 /// SharedRenderer is a type alias for an Arc-wrapped Renderer, allowing for shared ownership and concurrency.
 pub type SharedRenderer<K> = Arc<Renderer<K>>;
-
-#[derive(Clone, Debug)]
-struct VisualRow {
-    content_row: usize,
-    content_column: usize,
-    graphemes: StyledGraphemes,
-}
-
-#[derive(Clone, Debug)]
-struct LayoutEntry<K> {
-    index: K,
-    viewport: WidgetViewport,
-    rows: Vec<VisualRow>,
-}
-
-#[derive(Clone, Debug)]
-struct LayoutSnapshot<K> {
-    origin: ScreenPosition,
-    terminal_width: u16,
-    entries: Vec<LayoutEntry<K>>,
-}
 
 /// Renderer stores widget content, lays it out, and draws it to a terminal.
 pub struct Renderer<K: Clone + Ord + Send + Sync + 'static> {
     terminal: AsyncMutex<Terminal>,
     contents: SkipMap<K, CreatedGraphemes>,
-    viewport_rows: Mutex<BTreeMap<K, usize>>,
+    layout_engine: Mutex<RendererLayout<K>>,
     layout: RwLock<Option<LayoutSnapshot<K>>>,
 }
 
@@ -71,7 +47,7 @@ impl<K: Clone + Ord + Send + Sync + 'static> Renderer<K> {
                 position: crate::crossterm::cursor::position()?,
             }),
             contents: SkipMap::new(),
-            viewport_rows: Mutex::new(BTreeMap::new()),
+            layout_engine: Mutex::new(RendererLayout::default()),
             layout: RwLock::new(None),
         })
     }
@@ -104,10 +80,10 @@ impl<K: Clone + Ord + Send + Sync + 'static> Renderer<K> {
     where
         I: IntoIterator<Item = K>,
     {
-        let mut viewport_rows = self.viewport_rows.lock().expect("viewport lock poisoned");
+        let mut layout_engine = self.layout_engine.lock().expect("layout lock poisoned");
         items.into_iter().for_each(|index| {
             self.contents.remove(&index);
-            viewport_rows.remove(&index);
+            layout_engine.remove(&index);
         });
         self
     }
@@ -210,291 +186,39 @@ impl<K: Clone + Ord + Send + Sync + 'static> Renderer<K> {
 
         let mut terminal = self.terminal.lock().await;
         let (terminal_width, terminal_height) = crate::crossterm::terminal::size()?;
-        let laid_out = contents
-            .into_iter()
-            .map(|(index, created)| {
-                let rows = layout_content(&created, terminal_width as usize);
-                (index, created, rows)
-            })
-            .filter(|(_, created, rows)| !rows.is_empty() && created.layout.max_height != Some(0))
-            .collect::<Vec<_>>();
+        let prepared = self
+            .layout_engine
+            .lock()
+            .expect("layout lock poisoned")
+            .layout(contents, terminal_width, terminal_height)?;
 
-        if laid_out.len() > terminal_height as usize {
-            return Err(anyhow::anyhow!("Insufficient space to display all panes"));
-        }
-
-        let mut viewport_rows = self.viewport_rows.lock().expect("viewport lock poisoned");
-        let mut entries = Vec::with_capacity(laid_out.len());
-        let mut panes = Vec::with_capacity(laid_out.len());
-        let mut used_height = 0usize;
-
-        for (pane_index, (index, created, rows)) in laid_out.iter().enumerate() {
-            let panes_after = laid_out.len().saturating_sub(pane_index + 1);
-            let available = (terminal_height as usize)
-                .saturating_sub(used_height)
-                .saturating_sub(panes_after);
-            let desired = created
-                .layout
-                .max_height
-                .unwrap_or(rows.len())
-                .min(rows.len());
-            let height = desired.min(available).max(1);
-            used_height = used_height.saturating_add(height);
-
-            let mut viewport = WidgetViewport {
-                height: height as u16,
-                content_row: viewport_rows.get(index).copied().unwrap_or_default(),
-                ..Default::default()
-            };
-
-            let max_content_row = rows.len().saturating_sub(height);
-            viewport.content_row = viewport.content_row.min(max_content_row);
-
-            if let Some(cursor) = created.cursor
-                && let Some(position) = visual_position(rows, cursor)
-            {
-                viewport.scroll_to_include(position);
-                viewport.content_row = viewport.content_row.min(max_content_row);
-            }
-
-            viewport_rows.insert(index.clone(), viewport.content_row);
-            let visible_rows = rows
-                .iter()
-                .skip(viewport.content_row)
-                .take(height)
-                .map(|row| row.graphemes.clone())
-                .collect::<Vec<_>>();
-
-            panes.push(visible_rows);
-            entries.push(LayoutEntry {
-                index: index.clone(),
-                viewport,
-                rows: rows.clone(),
-            });
-        }
-        drop(viewport_rows);
-
-        terminal.draw_rows(&panes)?;
+        terminal.draw_rows(prepared.panes())?;
 
         let origin = ScreenPosition {
             row: terminal.position.1,
             column: terminal.position.0,
         };
-        let mut screen_row = origin.row;
-        for entry in &mut entries {
-            entry.viewport.screen_row = screen_row;
-            screen_row = screen_row.saturating_add(entry.viewport.height);
-        }
-
-        *self.layout.write().expect("layout lock poisoned") = Some(LayoutSnapshot {
-            origin,
-            terminal_width,
-            entries,
-        });
+        *self.layout.write().expect("layout lock poisoned") = Some(prepared.into_snapshot(origin));
 
         Ok(())
     }
 }
 
-fn layout_content(created: &CreatedGraphemes, width: usize) -> Vec<VisualRow> {
-    if width == 0 {
-        return Vec::new();
-    }
-
-    created
-        .graphemes
-        .logical_lines()
-        .into_iter()
-        .enumerate()
-        .flat_map(|(content_row, line)| match created.layout.width_mode {
-            WidthMode::Wrap => wrap_line(content_row, line, width),
-            WidthMode::Truncate => vec![VisualRow {
-                content_row,
-                content_column: 0,
-                graphemes: line.truncated_line_with_ellipsis(width, &StyledGraphemes::from("…")),
-            }],
-        })
-        .collect()
-}
-
-fn wrap_line(content_row: usize, line: StyledGraphemes, width: usize) -> Vec<VisualRow> {
-    if line.is_empty() {
-        return vec![VisualRow {
-            content_row,
-            content_column: 0,
-            graphemes: line,
-        }];
-    }
-
-    let mut rows = Vec::new();
-    let mut row = StyledGraphemes::default();
-    let mut row_width = 0usize;
-    let mut content_column = 0usize;
-    let mut row_column = 0usize;
-
-    for grapheme in line.iter() {
-        let grapheme_width = grapheme.width();
-        if grapheme_width > width {
-            if !row.is_empty() {
-                rows.push(VisualRow {
-                    content_row,
-                    content_column: row_column,
-                    graphemes: row,
-                });
-                row = StyledGraphemes::default();
-                row_width = 0;
-            }
-
-            // Keep the replacement on its own visual row: it occupies one screen
-            // cell while the original grapheme still advances by its logical width.
-            rows.push(VisualRow {
-                content_row,
-                content_column,
-                graphemes: StyledGraphemes::from("…"),
-            });
-            content_column = content_column.saturating_add(grapheme_width);
-            row_column = content_column;
-            continue;
-        }
-
-        if !row.is_empty() && row_width.saturating_add(grapheme_width) > width {
-            rows.push(VisualRow {
-                content_row,
-                content_column: row_column,
-                graphemes: row,
-            });
-            row = StyledGraphemes::default();
-            row_width = 0;
-            row_column = content_column;
-        }
-
-        row.push_back(grapheme.clone());
-        row_width = row_width.saturating_add(grapheme_width);
-        content_column = content_column.saturating_add(grapheme_width);
-    }
-
-    if !row.is_empty() {
-        rows.push(VisualRow {
-            content_row,
-            content_column: row_column,
-            graphemes: row,
-        });
-    }
-
-    rows
-}
-
-fn visual_position(rows: &[VisualRow], position: ContentPosition) -> Option<VisualPosition> {
-    let matching = rows
-        .iter()
-        .enumerate()
-        .filter(|(_, row)| row.content_row == position.row)
-        .collect::<Vec<_>>();
-
-    let (row_index, row) = matching
-        .iter()
-        .copied()
-        .find(|(_, row)| {
-            let end = row.content_column.saturating_add(row.graphemes.widths());
-            position.column >= row.content_column && position.column < end
-        })
-        .or_else(|| matching.last().copied())?;
-
-    Some(VisualPosition {
-        row: row_index,
-        column: position.column.saturating_sub(row.content_column),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::widget::{WidgetLayout, WidthMode};
-
-    #[test]
-    fn layout_maps_logical_cursor_to_wrapped_row() {
-        let created = CreatedGraphemes {
-            graphemes: StyledGraphemes::from("abcdefghij"),
-            cursor: Some(ContentPosition { row: 0, column: 8 }),
-            ..Default::default()
-        };
-        let rows = layout_content(&created, 4);
-
-        assert_eq!(rows.len(), 3);
-        assert_eq!(
-            visual_position(&rows, created.cursor.unwrap()),
-            Some(VisualPosition { row: 2, column: 0 })
-        );
-    }
-
-    #[test]
-    fn wrap_preserves_a_grapheme_wider_than_the_terminal() {
-        let created = CreatedGraphemes {
-            graphemes: StyledGraphemes::from("界"),
-            cursor: Some(ContentPosition { row: 0, column: 0 }),
-            ..Default::default()
-        };
-
-        let rows = layout_content(&created, 1);
-
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].content_row, 0);
-        assert_eq!(rows[0].content_column, 0);
-        assert_eq!(rows[0].graphemes.to_string(), "…");
-        assert_eq!(
-            visual_position(&rows, created.cursor.unwrap()),
-            Some(VisualPosition { row: 0, column: 0 })
-        );
-    }
-
-    #[test]
-    fn wrap_preserves_columns_after_a_grapheme_wider_than_the_terminal() {
-        let created = CreatedGraphemes {
-            graphemes: StyledGraphemes::from("界a"),
-            cursor: Some(ContentPosition { row: 0, column: 2 }),
-            ..Default::default()
-        };
-
-        let rows = layout_content(&created, 1);
-
-        assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].content_column, 0);
-        assert_eq!(rows[0].graphemes.to_string(), "…");
-        assert_eq!(rows[1].content_column, 2);
-        assert_eq!(rows[1].graphemes.to_string(), "a");
-        assert_eq!(
-            visual_position(&rows, created.cursor.unwrap()),
-            Some(VisualPosition { row: 1, column: 0 })
-        );
-    }
-
-    #[test]
-    fn truncate_keeps_one_visual_row_per_logical_row() {
-        let created = CreatedGraphemes {
-            graphemes: StyledGraphemes::from("abcdefghij\nsecond"),
-            layout: WidgetLayout {
-                width_mode: WidthMode::Truncate,
-                ..Default::default()
-            },
-            cursor: None,
-        };
-        let rows = layout_content(&created, 4);
-
-        assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].graphemes.to_string(), "abc…");
-        assert_eq!(rows[1].graphemes.to_string(), "sec…");
-    }
+    use crate::{grapheme::StyledGraphemes, widget::WidgetViewport};
 
     #[test]
     fn hit_test_and_screen_position_round_trip() {
         let renderer = Renderer {
             terminal: AsyncMutex::new(Terminal { position: (0, 0) }),
             contents: SkipMap::new(),
-            viewport_rows: Mutex::new(BTreeMap::new()),
+            layout_engine: Mutex::new(RendererLayout::default()),
             layout: RwLock::new(Some(LayoutSnapshot {
                 origin: ScreenPosition { row: 3, column: 0 },
                 terminal_width: 20,
-                entries: vec![LayoutEntry {
+                entries: vec![layout::LayoutEntry {
                     index: 7usize,
                     viewport: WidgetViewport {
                         screen_row: 3,
@@ -502,17 +226,17 @@ mod tests {
                         content_row: 1,
                     },
                     rows: vec![
-                        VisualRow {
+                        layout::VisualRow {
                             content_row: 0,
                             content_column: 0,
                             graphemes: StyledGraphemes::from("hidden"),
                         },
-                        VisualRow {
+                        layout::VisualRow {
                             content_row: 1,
                             content_column: 0,
                             graphemes: StyledGraphemes::from("first"),
                         },
-                        VisualRow {
+                        layout::VisualRow {
                             content_row: 2,
                             content_column: 0,
                             graphemes: StyledGraphemes::from("second"),

--- a/promkit-core/src/render/layout.rs
+++ b/promkit-core/src/render/layout.rs
@@ -1,0 +1,401 @@
+use std::collections::BTreeMap;
+
+use crate::{
+    grapheme::StyledGraphemes,
+    widget::{
+        ContentPosition, CreatedGraphemes, ScreenPosition, VisualPosition, WidgetViewport,
+        WidthMode,
+    },
+};
+
+/// Terminal-size-dependent renderer layout without terminal I/O.
+///
+/// The layout keeps each pane's vertical viewport offset between calls. This
+/// mirrors [`super::Renderer`] behavior while allowing layout performance to be
+/// measured independently from terminal size queries and stdout writes.
+#[derive(Debug)]
+pub struct RendererLayout<K> {
+    viewport_rows: BTreeMap<K, usize>,
+}
+
+impl<K> Default for RendererLayout<K> {
+    fn default() -> Self {
+        Self {
+            viewport_rows: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct VisualRow {
+    pub(super) content_row: usize,
+    pub(super) content_column: usize,
+    pub(super) graphemes: StyledGraphemes,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct LayoutEntry<K> {
+    pub(super) index: K,
+    pub(super) viewport: WidgetViewport,
+    pub(super) rows: Vec<VisualRow>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct LayoutSnapshot<K> {
+    pub(super) origin: ScreenPosition,
+    pub(super) terminal_width: u16,
+    pub(super) entries: Vec<LayoutEntry<K>>,
+}
+
+/// A renderer frame after wrapping, viewport allocation, and clipping.
+///
+/// It intentionally exposes only aggregate information and the visible panes.
+/// Coordinate mappings are installed by [`super::Renderer`] after the panes
+/// have been drawn at a known screen origin.
+#[derive(Debug)]
+pub struct PreparedLayout<K> {
+    pub(super) terminal_width: u16,
+    pub(super) entries: Vec<LayoutEntry<K>>,
+    pub(super) panes: Vec<Vec<StyledGraphemes>>,
+}
+
+impl<K> PreparedLayout<K> {
+    /// Returns the visible rows grouped by renderer pane.
+    pub fn panes(&self) -> &[Vec<StyledGraphemes>] {
+        &self.panes
+    }
+
+    /// Returns the number of non-empty panes allocated in this frame.
+    pub fn pane_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns the number of visual rows produced before viewport clipping.
+    pub fn visual_row_count(&self) -> usize {
+        self.entries.iter().map(|entry| entry.rows.len()).sum()
+    }
+
+    /// Returns the number of rows that will be written to the terminal.
+    pub fn visible_row_count(&self) -> usize {
+        self.panes.iter().map(Vec::len).sum()
+    }
+
+    pub(super) fn into_snapshot(mut self, origin: ScreenPosition) -> LayoutSnapshot<K> {
+        let mut screen_row = origin.row;
+        for entry in &mut self.entries {
+            entry.viewport.screen_row = screen_row;
+            screen_row = screen_row.saturating_add(entry.viewport.height);
+        }
+
+        LayoutSnapshot {
+            origin,
+            terminal_width: self.terminal_width,
+            entries: self.entries,
+        }
+    }
+}
+
+impl<K: Clone + Ord> RendererLayout<K> {
+    /// Lays out a renderer frame for a known terminal size.
+    ///
+    /// This performs the same content wrapping, truncation, pane allocation,
+    /// cursor scrolling, and visible-row cloning used by
+    /// [`super::Renderer::render`], but performs no terminal I/O.
+    pub fn layout<I>(
+        &mut self,
+        contents: I,
+        terminal_width: u16,
+        terminal_height: u16,
+    ) -> anyhow::Result<PreparedLayout<K>>
+    where
+        I: IntoIterator<Item = (K, CreatedGraphemes)>,
+    {
+        let laid_out = contents
+            .into_iter()
+            .map(|(index, created)| {
+                let rows = layout_content(&created, terminal_width as usize);
+                (index, created, rows)
+            })
+            .filter(|(_, created, rows)| !rows.is_empty() && created.layout.max_height != Some(0))
+            .collect::<Vec<_>>();
+
+        if laid_out.len() > terminal_height as usize {
+            return Err(anyhow::anyhow!("Insufficient space to display all panes"));
+        }
+
+        let mut entries = Vec::with_capacity(laid_out.len());
+        let mut panes = Vec::with_capacity(laid_out.len());
+        let mut used_height = 0usize;
+
+        for (pane_index, (index, created, rows)) in laid_out.iter().enumerate() {
+            let panes_after = laid_out.len().saturating_sub(pane_index + 1);
+            let available = (terminal_height as usize)
+                .saturating_sub(used_height)
+                .saturating_sub(panes_after);
+            let desired = created
+                .layout
+                .max_height
+                .unwrap_or(rows.len())
+                .min(rows.len());
+            let height = desired.min(available).max(1);
+            used_height = used_height.saturating_add(height);
+
+            let mut viewport = WidgetViewport {
+                height: height as u16,
+                content_row: self.viewport_rows.get(index).copied().unwrap_or_default(),
+                ..Default::default()
+            };
+
+            let max_content_row = rows.len().saturating_sub(height);
+            viewport.content_row = viewport.content_row.min(max_content_row);
+
+            if let Some(cursor) = created.cursor
+                && let Some(position) = visual_position(rows, cursor)
+            {
+                viewport.scroll_to_include(position);
+                viewport.content_row = viewport.content_row.min(max_content_row);
+            }
+
+            self.viewport_rows
+                .insert(index.clone(), viewport.content_row);
+            let visible_rows = rows
+                .iter()
+                .skip(viewport.content_row)
+                .take(height)
+                .map(|row| row.graphemes.clone())
+                .collect::<Vec<_>>();
+
+            panes.push(visible_rows);
+            entries.push(LayoutEntry {
+                index: index.clone(),
+                viewport,
+                rows: rows.clone(),
+            });
+        }
+
+        Ok(PreparedLayout {
+            terminal_width,
+            entries,
+            panes,
+        })
+    }
+
+    pub(super) fn remove(&mut self, index: &K) {
+        self.viewport_rows.remove(index);
+    }
+}
+
+fn layout_content(created: &CreatedGraphemes, width: usize) -> Vec<VisualRow> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    created
+        .graphemes
+        .logical_lines()
+        .into_iter()
+        .enumerate()
+        .flat_map(|(content_row, line)| match created.layout.width_mode {
+            WidthMode::Wrap => wrap_line(content_row, line, width),
+            WidthMode::Truncate => vec![VisualRow {
+                content_row,
+                content_column: 0,
+                graphemes: line.truncated_line_with_ellipsis(width, &StyledGraphemes::from("…")),
+            }],
+        })
+        .collect()
+}
+
+fn wrap_line(content_row: usize, line: StyledGraphemes, width: usize) -> Vec<VisualRow> {
+    if line.is_empty() {
+        return vec![VisualRow {
+            content_row,
+            content_column: 0,
+            graphemes: line,
+        }];
+    }
+
+    let mut rows = Vec::new();
+    let mut row = StyledGraphemes::default();
+    let mut row_width = 0usize;
+    let mut content_column = 0usize;
+    let mut row_column = 0usize;
+
+    for grapheme in line.iter() {
+        let grapheme_width = grapheme.width();
+        if grapheme_width > width {
+            if !row.is_empty() {
+                rows.push(VisualRow {
+                    content_row,
+                    content_column: row_column,
+                    graphemes: row,
+                });
+                row = StyledGraphemes::default();
+                row_width = 0;
+            }
+
+            // Keep the replacement on its own visual row: it occupies one screen
+            // cell while the original grapheme still advances by its logical width.
+            rows.push(VisualRow {
+                content_row,
+                content_column,
+                graphemes: StyledGraphemes::from("…"),
+            });
+            content_column = content_column.saturating_add(grapheme_width);
+            row_column = content_column;
+            continue;
+        }
+
+        if !row.is_empty() && row_width.saturating_add(grapheme_width) > width {
+            rows.push(VisualRow {
+                content_row,
+                content_column: row_column,
+                graphemes: row,
+            });
+            row = StyledGraphemes::default();
+            row_width = 0;
+            row_column = content_column;
+        }
+
+        row.push_back(grapheme.clone());
+        row_width = row_width.saturating_add(grapheme_width);
+        content_column = content_column.saturating_add(grapheme_width);
+    }
+
+    if !row.is_empty() {
+        rows.push(VisualRow {
+            content_row,
+            content_column: row_column,
+            graphemes: row,
+        });
+    }
+
+    rows
+}
+
+pub(super) fn visual_position(
+    rows: &[VisualRow],
+    position: ContentPosition,
+) -> Option<VisualPosition> {
+    let matching = rows
+        .iter()
+        .enumerate()
+        .filter(|(_, row)| row.content_row == position.row)
+        .collect::<Vec<_>>();
+
+    let (row_index, row) = matching
+        .iter()
+        .copied()
+        .find(|(_, row)| {
+            let end = row.content_column.saturating_add(row.graphemes.widths());
+            position.column >= row.content_column && position.column < end
+        })
+        .or_else(|| matching.last().copied())?;
+
+    Some(VisualPosition {
+        row: row_index,
+        column: position.column.saturating_sub(row.content_column),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widget::WidgetLayout;
+
+    #[test]
+    fn layout_maps_logical_cursor_to_wrapped_row() {
+        let created = CreatedGraphemes {
+            graphemes: StyledGraphemes::from("abcdefghij"),
+            cursor: Some(ContentPosition { row: 0, column: 8 }),
+            ..Default::default()
+        };
+        let rows = layout_content(&created, 4);
+
+        assert_eq!(rows.len(), 3);
+        assert_eq!(
+            visual_position(&rows, created.cursor.unwrap()),
+            Some(VisualPosition { row: 2, column: 0 })
+        );
+    }
+
+    #[test]
+    fn wrap_preserves_a_grapheme_wider_than_the_terminal() {
+        let created = CreatedGraphemes {
+            graphemes: StyledGraphemes::from("界"),
+            cursor: Some(ContentPosition { row: 0, column: 0 }),
+            ..Default::default()
+        };
+
+        let rows = layout_content(&created, 1);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].content_row, 0);
+        assert_eq!(rows[0].content_column, 0);
+        assert_eq!(rows[0].graphemes.to_string(), "…");
+        assert_eq!(
+            visual_position(&rows, created.cursor.unwrap()),
+            Some(VisualPosition { row: 0, column: 0 })
+        );
+    }
+
+    #[test]
+    fn wrap_preserves_columns_after_a_grapheme_wider_than_the_terminal() {
+        let created = CreatedGraphemes {
+            graphemes: StyledGraphemes::from("界a"),
+            cursor: Some(ContentPosition { row: 0, column: 2 }),
+            ..Default::default()
+        };
+
+        let rows = layout_content(&created, 1);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].content_column, 0);
+        assert_eq!(rows[0].graphemes.to_string(), "…");
+        assert_eq!(rows[1].content_column, 2);
+        assert_eq!(rows[1].graphemes.to_string(), "a");
+        assert_eq!(
+            visual_position(&rows, created.cursor.unwrap()),
+            Some(VisualPosition { row: 1, column: 0 })
+        );
+    }
+
+    #[test]
+    fn truncate_keeps_one_visual_row_per_logical_row() {
+        let created = CreatedGraphemes {
+            graphemes: StyledGraphemes::from("abcdefghij\nsecond"),
+            layout: WidgetLayout {
+                width_mode: WidthMode::Truncate,
+                ..Default::default()
+            },
+            cursor: None,
+        };
+        let rows = layout_content(&created, 4);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].graphemes.to_string(), "abc…");
+        assert_eq!(rows[1].graphemes.to_string(), "sec…");
+    }
+
+    #[test]
+    fn allocates_height_and_preserves_viewport_between_frames() {
+        let created = CreatedGraphemes {
+            graphemes: StyledGraphemes::from("first\nsecond\nthird"),
+            layout: WidgetLayout {
+                max_height: Some(2),
+                ..Default::default()
+            },
+            cursor: Some(ContentPosition { row: 2, column: 0 }),
+        };
+        let mut layout = RendererLayout::default();
+
+        let first = layout.layout([(0, created.clone())], 80, 24).unwrap();
+        assert_eq!(first.pane_count(), 1);
+        assert_eq!(first.visual_row_count(), 3);
+        assert_eq!(first.visible_row_count(), 2);
+        assert_eq!(first.panes()[0][0].to_string(), "second");
+
+        let second = layout.layout([(0, created)], 80, 24).unwrap();
+        assert_eq!(second.panes()[0][0].to_string(), "second");
+    }
+}


### PR DESCRIPTION
## Summary

- Extract terminal-size-dependent layout from `Renderer` into `RendererLayout`
- Add Criterion benchmarks covering:
  - ASCII and wide/combining characters
  - wrapping and truncation
  - content size and terminal width
  - pane count
  - viewport movement
- Keep terminal I/O outside the benchmark
- Document the benchmark command and rendering boundary

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features -- --nocapture --format pretty`
- `cargo bench -p promkit-core --bench renderer_layout -- --test`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p promkit-core --no-deps`