### PR TITLE
perf(core): reduce renderer layout cloning

### DIFF
--- a/promkit-core/benches/renderer_layout.rs
+++ b/promkit-core/benches/renderer_layout.rs
@@ -64,11 +64,11 @@ fn content_size(c: &mut Criterion) {
                     &contents,
                     |b, contents| {
                         b.iter(|| {
-                            black_box(
-                                layout
-                                    .layout(black_box(contents.clone()), 80, TERMINAL_HEIGHT)
-                                    .unwrap(),
-                            )
+                            let prepared = layout
+                                .layout(black_box(contents.clone()), 80, TERMINAL_HEIGHT)
+                                .unwrap();
+                            black_box(prepared.panes());
+                            black_box(prepared)
                         });
                     },
                 );
@@ -96,11 +96,11 @@ fn terminal_width(c: &mut Criterion) {
         let mut layout = RendererLayout::default();
         group.bench_with_input(BenchmarkId::from_parameter(width), &width, |b, &width| {
             b.iter(|| {
-                black_box(
-                    layout
-                        .layout(black_box(contents.clone()), width, TERMINAL_HEIGHT)
-                        .unwrap(),
-                )
+                let prepared = layout
+                    .layout(black_box(contents.clone()), width, TERMINAL_HEIGHT)
+                    .unwrap();
+                black_box(prepared.panes());
+                black_box(prepared)
             });
         });
     }
@@ -128,15 +128,15 @@ fn pane_count(c: &mut Criterion) {
             &contents,
             |b, contents| {
                 b.iter(|| {
-                    black_box(
-                        layout
-                            .layout(
-                                black_box(contents.clone()),
-                                80,
-                                u16::try_from(pane_count.max(TERMINAL_HEIGHT as usize)).unwrap(),
-                            )
-                            .unwrap(),
-                    )
+                    let prepared = layout
+                        .layout(
+                            black_box(contents.clone()),
+                            80,
+                            u16::try_from(pane_count.max(TERMINAL_HEIGHT as usize)).unwrap(),
+                        )
+                        .unwrap();
+                    black_box(prepared.panes());
+                    black_box(prepared)
                 });
             },
         );
@@ -167,11 +167,11 @@ fn cursor_scrolling(c: &mut Criterion) {
             });
             at_tail = !at_tail;
 
-            black_box(
-                layout
-                    .layout(black_box([(0usize, frame)]), 80, TERMINAL_HEIGHT)
-                    .unwrap(),
-            )
+            let prepared = layout
+                .layout(black_box([(0usize, frame)]), 80, TERMINAL_HEIGHT)
+                .unwrap();
+            black_box(prepared.panes());
+            black_box(prepared)
         });
     });
 

--- a/promkit-core/src/render.rs
+++ b/promkit-core/src/render.rs
@@ -192,7 +192,9 @@ impl<K: Clone + Ord + Send + Sync + 'static> Renderer<K> {
             .expect("layout lock poisoned")
             .layout(contents, terminal_width, terminal_height)?;
 
-        terminal.draw_rows(prepared.panes())?;
+        let panes = prepared.panes();
+        terminal.draw_rows(&panes)?;
+        drop(panes);
 
         let origin = ScreenPosition {
             row: terminal.position.1,

--- a/promkit-core/src/render/layout.rs
+++ b/promkit-core/src/render/layout.rs
@@ -49,20 +49,31 @@ pub(super) struct LayoutSnapshot<K> {
 
 /// A renderer frame after wrapping, viewport allocation, and clipping.
 ///
-/// It intentionally exposes only aggregate information and the visible panes.
+/// It intentionally exposes only aggregate information and views of the visible
+/// panes.
 /// Coordinate mappings are installed by [`super::Renderer`] after the panes
 /// have been drawn at a known screen origin.
 #[derive(Debug)]
 pub struct PreparedLayout<K> {
     pub(super) terminal_width: u16,
     pub(super) entries: Vec<LayoutEntry<K>>,
-    pub(super) panes: Vec<Vec<StyledGraphemes>>,
 }
 
 impl<K> PreparedLayout<K> {
-    /// Returns the visible rows grouped by renderer pane.
-    pub fn panes(&self) -> &[Vec<StyledGraphemes>] {
-        &self.panes
+    /// Returns views of the visible rows grouped by renderer pane.
+    pub fn panes(&self) -> Vec<Vec<&StyledGraphemes>> {
+        self.entries
+            .iter()
+            .map(|entry| {
+                entry
+                    .rows
+                    .iter()
+                    .skip(entry.viewport.content_row)
+                    .take(entry.viewport.height as usize)
+                    .map(|row| &row.graphemes)
+                    .collect()
+            })
+            .collect()
     }
 
     /// Returns the number of non-empty panes allocated in this frame.
@@ -77,7 +88,16 @@ impl<K> PreparedLayout<K> {
 
     /// Returns the number of rows that will be written to the terminal.
     pub fn visible_row_count(&self) -> usize {
-        self.panes.iter().map(Vec::len).sum()
+        self.entries
+            .iter()
+            .map(|entry| {
+                entry
+                    .rows
+                    .len()
+                    .saturating_sub(entry.viewport.content_row)
+                    .min(entry.viewport.height as usize)
+            })
+            .sum()
     }
 
     pub(super) fn into_snapshot(mut self, origin: ScreenPosition) -> LayoutSnapshot<K> {
@@ -99,8 +119,8 @@ impl<K: Clone + Ord> RendererLayout<K> {
     /// Lays out a renderer frame for a known terminal size.
     ///
     /// This performs the same content wrapping, truncation, pane allocation,
-    /// cursor scrolling, and visible-row cloning used by
-    /// [`super::Renderer::render`], but performs no terminal I/O.
+    /// cursor scrolling, and viewport clipping used by [`super::Renderer::render`],
+    /// but performs no terminal I/O.
     pub fn layout<I>(
         &mut self,
         contents: I,
@@ -113,10 +133,15 @@ impl<K: Clone + Ord> RendererLayout<K> {
         let laid_out = contents
             .into_iter()
             .map(|(index, created)| {
-                let rows = layout_content(&created, terminal_width as usize);
-                (index, created, rows)
+                let CreatedGraphemes {
+                    graphemes,
+                    layout,
+                    cursor,
+                } = created;
+                let rows = layout_content(graphemes, layout.width_mode, terminal_width as usize);
+                (index, layout, cursor, rows)
             })
-            .filter(|(_, created, rows)| !rows.is_empty() && created.layout.max_height != Some(0))
+            .filter(|(_, layout, _, rows)| !rows.is_empty() && layout.max_height != Some(0))
             .collect::<Vec<_>>();
 
         if laid_out.len() > terminal_height as usize {
@@ -124,33 +149,29 @@ impl<K: Clone + Ord> RendererLayout<K> {
         }
 
         let mut entries = Vec::with_capacity(laid_out.len());
-        let mut panes = Vec::with_capacity(laid_out.len());
         let mut used_height = 0usize;
+        let pane_count = laid_out.len();
 
-        for (pane_index, (index, created, rows)) in laid_out.iter().enumerate() {
-            let panes_after = laid_out.len().saturating_sub(pane_index + 1);
+        for (pane_index, (index, layout, cursor, rows)) in laid_out.into_iter().enumerate() {
+            let panes_after = pane_count.saturating_sub(pane_index + 1);
             let available = (terminal_height as usize)
                 .saturating_sub(used_height)
                 .saturating_sub(panes_after);
-            let desired = created
-                .layout
-                .max_height
-                .unwrap_or(rows.len())
-                .min(rows.len());
+            let desired = layout.max_height.unwrap_or(rows.len()).min(rows.len());
             let height = desired.min(available).max(1);
             used_height = used_height.saturating_add(height);
 
             let mut viewport = WidgetViewport {
                 height: height as u16,
-                content_row: self.viewport_rows.get(index).copied().unwrap_or_default(),
+                content_row: self.viewport_rows.get(&index).copied().unwrap_or_default(),
                 ..Default::default()
             };
 
             let max_content_row = rows.len().saturating_sub(height);
             viewport.content_row = viewport.content_row.min(max_content_row);
 
-            if let Some(cursor) = created.cursor
-                && let Some(position) = visual_position(rows, cursor)
+            if let Some(cursor) = cursor
+                && let Some(position) = visual_position(&rows, cursor)
             {
                 viewport.scroll_to_include(position);
                 viewport.content_row = viewport.content_row.min(max_content_row);
@@ -158,25 +179,16 @@ impl<K: Clone + Ord> RendererLayout<K> {
 
             self.viewport_rows
                 .insert(index.clone(), viewport.content_row);
-            let visible_rows = rows
-                .iter()
-                .skip(viewport.content_row)
-                .take(height)
-                .map(|row| row.graphemes.clone())
-                .collect::<Vec<_>>();
-
-            panes.push(visible_rows);
             entries.push(LayoutEntry {
-                index: index.clone(),
+                index,
                 viewport,
-                rows: rows.clone(),
+                rows,
             });
         }
 
         Ok(PreparedLayout {
             terminal_width,
             entries,
-            panes,
         })
     }
 
@@ -185,25 +197,54 @@ impl<K: Clone + Ord> RendererLayout<K> {
     }
 }
 
-fn layout_content(created: &CreatedGraphemes, width: usize) -> Vec<VisualRow> {
+fn layout_content(
+    graphemes: StyledGraphemes,
+    width_mode: WidthMode,
+    width: usize,
+) -> Vec<VisualRow> {
     if width == 0 {
         return Vec::new();
     }
 
-    created
-        .graphemes
-        .logical_lines()
+    into_logical_lines(graphemes)
         .into_iter()
         .enumerate()
-        .flat_map(|(content_row, line)| match created.layout.width_mode {
+        .flat_map(|(content_row, line)| match width_mode {
             WidthMode::Wrap => wrap_line(content_row, line, width),
             WidthMode::Truncate => vec![VisualRow {
                 content_row,
                 content_column: 0,
-                graphemes: line.truncated_line_with_ellipsis(width, &StyledGraphemes::from("…")),
+                graphemes: truncate_line(line, width),
             }],
         })
         .collect()
+}
+
+fn into_logical_lines(graphemes: StyledGraphemes) -> Vec<StyledGraphemes> {
+    if graphemes.is_empty() {
+        return Vec::new();
+    }
+
+    let mut lines = Vec::new();
+    let mut line = StyledGraphemes::default();
+    let mut last_was_newline = false;
+
+    for styled in graphemes.0 {
+        if styled.character() == '\n' {
+            lines.push(line);
+            line = StyledGraphemes::default();
+            last_was_newline = true;
+        } else {
+            line.push_back(styled);
+            last_was_newline = false;
+        }
+    }
+
+    if !line.is_empty() || last_was_newline {
+        lines.push(line);
+    }
+
+    lines
 }
 
 fn wrap_line(content_row: usize, line: StyledGraphemes, width: usize) -> Vec<VisualRow> {
@@ -221,7 +262,7 @@ fn wrap_line(content_row: usize, line: StyledGraphemes, width: usize) -> Vec<Vis
     let mut content_column = 0usize;
     let mut row_column = 0usize;
 
-    for grapheme in line.iter() {
+    for grapheme in line.0 {
         let grapheme_width = grapheme.width();
         if grapheme_width > width {
             if !row.is_empty() {
@@ -257,7 +298,7 @@ fn wrap_line(content_row: usize, line: StyledGraphemes, width: usize) -> Vec<Vis
             row_column = content_column;
         }
 
-        row.push_back(grapheme.clone());
+        row.push_back(grapheme);
         row_width = row_width.saturating_add(grapheme_width);
         content_column = content_column.saturating_add(grapheme_width);
     }
@@ -271,6 +312,38 @@ fn wrap_line(content_row: usize, line: StyledGraphemes, width: usize) -> Vec<Vis
     }
 
     rows
+}
+
+fn truncate_line(line: StyledGraphemes, width: usize) -> StyledGraphemes {
+    if line.widths() <= width {
+        return line;
+    }
+
+    if width == 0 {
+        return StyledGraphemes::default();
+    }
+
+    let mut ellipsis = StyledGraphemes::from("…");
+    let ellipsis_width = ellipsis.widths();
+    if width <= ellipsis_width {
+        return ellipsis;
+    }
+
+    let mut truncated = StyledGraphemes::default();
+    let mut current_width = 0usize;
+    for grapheme in line.0 {
+        if current_width
+            .saturating_add(grapheme.width())
+            .saturating_add(ellipsis_width)
+            > width
+        {
+            break;
+        }
+        current_width = current_width.saturating_add(grapheme.width());
+        truncated.push_back(grapheme);
+    }
+    truncated.append(&mut ellipsis);
+    truncated
 }
 
 pub(super) fn visual_position(
@@ -310,11 +383,12 @@ mod tests {
             cursor: Some(ContentPosition { row: 0, column: 8 }),
             ..Default::default()
         };
-        let rows = layout_content(&created, 4);
+        let cursor = created.cursor.unwrap();
+        let rows = layout_content(created.graphemes, created.layout.width_mode, 4);
 
         assert_eq!(rows.len(), 3);
         assert_eq!(
-            visual_position(&rows, created.cursor.unwrap()),
+            visual_position(&rows, cursor),
             Some(VisualPosition { row: 2, column: 0 })
         );
     }
@@ -327,14 +401,15 @@ mod tests {
             ..Default::default()
         };
 
-        let rows = layout_content(&created, 1);
+        let cursor = created.cursor.unwrap();
+        let rows = layout_content(created.graphemes, created.layout.width_mode, 1);
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].content_row, 0);
         assert_eq!(rows[0].content_column, 0);
         assert_eq!(rows[0].graphemes.to_string(), "…");
         assert_eq!(
-            visual_position(&rows, created.cursor.unwrap()),
+            visual_position(&rows, cursor),
             Some(VisualPosition { row: 0, column: 0 })
         );
     }
@@ -347,7 +422,8 @@ mod tests {
             ..Default::default()
         };
 
-        let rows = layout_content(&created, 1);
+        let cursor = created.cursor.unwrap();
+        let rows = layout_content(created.graphemes, created.layout.width_mode, 1);
 
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].content_column, 0);
@@ -355,7 +431,7 @@ mod tests {
         assert_eq!(rows[1].content_column, 2);
         assert_eq!(rows[1].graphemes.to_string(), "a");
         assert_eq!(
-            visual_position(&rows, created.cursor.unwrap()),
+            visual_position(&rows, cursor),
             Some(VisualPosition { row: 1, column: 0 })
         );
     }
@@ -370,11 +446,22 @@ mod tests {
             },
             cursor: None,
         };
-        let rows = layout_content(&created, 4);
+        let rows = layout_content(created.graphemes, created.layout.width_mode, 4);
 
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].graphemes.to_string(), "abc…");
         assert_eq!(rows[1].graphemes.to_string(), "sec…");
+    }
+
+    #[test]
+    fn layout_preserves_empty_logical_rows() {
+        let rows = layout_content(StyledGraphemes::from("first\n\n"), WidthMode::Wrap, 80);
+        let text = rows
+            .iter()
+            .map(|row| row.graphemes.to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(text, ["first", "", ""]);
     }
 
     #[test]
@@ -393,9 +480,11 @@ mod tests {
         assert_eq!(first.pane_count(), 1);
         assert_eq!(first.visual_row_count(), 3);
         assert_eq!(first.visible_row_count(), 2);
-        assert_eq!(first.panes()[0][0].to_string(), "second");
+        let first_panes = first.panes();
+        assert_eq!(first_panes[0][0].to_string(), "second");
 
         let second = layout.layout([(0, created)], 80, 24).unwrap();
-        assert_eq!(second.panes()[0][0].to_string(), "second");
+        let second_panes = second.panes();
+        assert_eq!(second_panes[0][0].to_string(), "second");
     }
 }

--- a/promkit-core/src/terminal.rs
+++ b/promkit-core/src/terminal.rs
@@ -1,4 +1,7 @@
-use std::io::{self, Write};
+use std::{
+    borrow::Borrow,
+    io::{self, Write},
+};
 
 use crate::{
     crossterm::{cursor, style, terminal},
@@ -38,7 +41,10 @@ impl Terminal {
     }
 
     /// Draws panes that have already been wrapped and clipped by the renderer.
-    pub fn draw_rows(&mut self, panes: &[Vec<StyledGraphemes>]) -> anyhow::Result<()> {
+    pub fn draw_rows<R>(&mut self, panes: &[Vec<R>]) -> anyhow::Result<()>
+    where
+        R: Borrow<StyledGraphemes>,
+    {
         let (_, height) = terminal::size()?;
         let visible_height = height.saturating_sub(self.position.1);
         let row_count = panes.iter().map(Vec::len).sum::<usize>();
@@ -57,7 +63,7 @@ impl Terminal {
 
         for (pane_index, rows) in panes.iter().enumerate() {
             for (row_index, row) in rows.iter().enumerate() {
-                crossterm::queue!(io::stdout(), style::Print(row.styled_display()))?;
+                crossterm::queue!(io::stdout(), style::Print(row.borrow().styled_display()))?;
 
                 remaining_lines = remaining_lines.saturating_sub(1);
 


### PR DESCRIPTION
## Summary

- Move `StyledGrapheme` values through logical-line splitting, wrapping, and truncation
- Remove redundant `rows.clone()` when creating layout snapshots
- Draw visible panes through borrowed rows instead of cloning their contents
- Include pane-view construction in the renderer layout benchmarks

The initial clone needed to snapshot `Renderer` contents remains, but subsequent per-grapheme clones during layout are eliminated.

## Benchmark results

- ASCII 1 MiB wrap: ~17% faster
- ASCII 1 MiB truncate: ~31% faster
- 100 panes: ~12% faster
- Cursor head-to-tail: ~6% faster

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets`
- `cargo clippy -p promkit-core --lib -- -D warnings`