### PR TITLE
fix(core): preserve readline output across rapid terminal resize

### DIFF
--- a/promkit-core/src/render.rs
+++ b/promkit-core/src/render.rs
@@ -15,7 +15,10 @@
 //! positions against what was actually drawn rather than against newer,
 //! not-yet-rendered content.
 
-use std::sync::{Arc, Mutex, RwLock};
+use std::{
+    sync::{Arc, Mutex, RwLock},
+    time::{Duration, Instant},
+};
 
 use crossbeam_skiplist::SkipMap;
 use tokio::sync::Mutex as AsyncMutex;
@@ -29,6 +32,9 @@ mod layout;
 use layout::LayoutSnapshot;
 pub use layout::{PreparedLayout, RendererLayout};
 
+const RESIZE_SIZE_STABILITY: Duration = Duration::from_millis(20);
+const RESIZE_SIZE_POLL: Duration = Duration::from_millis(5);
+
 /// SharedRenderer is a type alias for an Arc-wrapped Renderer, allowing for shared ownership and concurrency.
 pub type SharedRenderer<K> = Arc<Renderer<K>>;
 
@@ -38,17 +44,17 @@ pub struct Renderer<K: Clone + Ord + Send + Sync + 'static> {
     contents: SkipMap<K, CreatedGraphemes>,
     layout_engine: Mutex<RendererLayout<K>>,
     layout: RwLock<Option<LayoutSnapshot<K>>>,
+    last_terminal_size: Mutex<Option<(u16, u16)>>,
 }
 
 impl<K: Clone + Ord + Send + Sync + 'static> Renderer<K> {
     pub fn try_new() -> anyhow::Result<Self> {
         Ok(Self {
-            terminal: AsyncMutex::new(Terminal {
-                position: crate::crossterm::cursor::position()?,
-            }),
+            terminal: AsyncMutex::new(Terminal::new(crate::crossterm::cursor::position()?)),
             contents: SkipMap::new(),
             layout_engine: Mutex::new(RendererLayout::default()),
             layout: RwLock::new(None),
+            last_terminal_size: Mutex::new(None),
         })
     }
 
@@ -185,24 +191,61 @@ impl<K: Clone + Ord + Send + Sync + 'static> Renderer<K> {
             .collect::<Vec<_>>();
 
         let mut terminal = self.terminal.lock().await;
-        let (terminal_width, terminal_height) = crate::crossterm::terminal::size()?;
-        let prepared = self
-            .layout_engine
+        let mut size = crate::crossterm::terminal::size()?;
+        let previous_size = *self
+            .last_terminal_size
             .lock()
-            .expect("layout lock poisoned")
-            .layout(contents, terminal_width, terminal_height)?;
+            .expect("terminal size lock poisoned");
+        if previous_size.is_some_and(|previous| previous != size) {
+            size = wait_for_terminal_size_stability(size).await?;
+        }
 
-        let panes = prepared.panes();
-        terminal.draw_rows(&panes)?;
-        drop(panes);
+        loop {
+            let (terminal_width, terminal_height) = size;
+            let prepared = self
+                .layout_engine
+                .lock()
+                .expect("layout lock poisoned")
+                .layout(contents.iter().cloned(), terminal_width, terminal_height)?;
 
-        let origin = ScreenPosition {
-            row: terminal.position.1,
-            column: terminal.position.0,
-        };
-        *self.layout.write().expect("layout lock poisoned") = Some(prepared.into_snapshot(origin));
+            let panes = prepared.panes();
+            terminal.draw_rows_at_height(&panes, terminal_height)?;
+            drop(panes);
 
-        Ok(())
+            let current_size = crate::crossterm::terminal::size()?;
+            if current_size != size {
+                size = wait_for_terminal_size_stability(current_size).await?;
+                continue;
+            }
+
+            let origin = ScreenPosition {
+                row: terminal.position.1,
+                column: terminal.position.0,
+            };
+            *self.layout.write().expect("layout lock poisoned") =
+                Some(prepared.into_snapshot(origin));
+            *self
+                .last_terminal_size
+                .lock()
+                .expect("terminal size lock poisoned") = Some(size);
+
+            return Ok(());
+        }
+    }
+}
+
+async fn wait_for_terminal_size_stability(mut previous: (u16, u16)) -> std::io::Result<(u16, u16)> {
+    let mut stable_since = Instant::now();
+
+    loop {
+        tokio::time::sleep(RESIZE_SIZE_POLL).await;
+        let current = crate::crossterm::terminal::size()?;
+        if current != previous {
+            previous = current;
+            stable_since = Instant::now();
+        } else if stable_since.elapsed() >= RESIZE_SIZE_STABILITY {
+            return Ok(current);
+        }
     }
 }
 
@@ -214,7 +257,7 @@ mod tests {
     #[test]
     fn hit_test_and_screen_position_round_trip() {
         let renderer = Renderer {
-            terminal: AsyncMutex::new(Terminal { position: (0, 0) }),
+            terminal: AsyncMutex::new(Terminal::new((0, 0))),
             contents: SkipMap::new(),
             layout_engine: Mutex::new(RendererLayout::default()),
             layout: RwLock::new(Some(LayoutSnapshot {
@@ -246,6 +289,7 @@ mod tests {
                     ],
                 }],
             })),
+            last_terminal_size: Mutex::new(None),
         };
 
         let screen = ScreenPosition { row: 4, column: 2 };

--- a/promkit-core/src/terminal.rs
+++ b/promkit-core/src/terminal.rs
@@ -46,6 +46,20 @@ impl Terminal {
         R: Borrow<StyledGraphemes>,
     {
         let (_, height) = terminal::size()?;
+        let mut stdout = io::stdout();
+        self.draw_rows_to(&mut stdout, panes, height)
+    }
+
+    fn draw_rows_to<W, R>(
+        &mut self,
+        writer: &mut W,
+        panes: &[Vec<R>],
+        height: u16,
+    ) -> anyhow::Result<()>
+    where
+        W: Write,
+        R: Borrow<StyledGraphemes>,
+    {
         let visible_height = height.saturating_sub(self.position.1);
         let row_count = panes.iter().map(Vec::len).sum::<usize>();
 
@@ -54,7 +68,7 @@ impl Terminal {
         }
 
         crossterm::queue!(
-            io::stdout(),
+            writer,
             cursor::MoveTo(self.position.0, self.position.1),
             terminal::Clear(terminal::ClearType::FromCursorDown),
         )?;
@@ -63,7 +77,7 @@ impl Terminal {
 
         for (pane_index, rows) in panes.iter().enumerate() {
             for (row_index, row) in rows.iter().enumerate() {
-                crossterm::queue!(io::stdout(), style::Print(row.borrow().styled_display()))?;
+                crossterm::queue!(writer, style::Print(row.borrow().styled_display()))?;
 
                 remaining_lines = remaining_lines.saturating_sub(1);
 
@@ -75,14 +89,109 @@ impl Terminal {
                 let has_more_content = !(is_last_pane && is_last_row_in_pane);
 
                 if has_more_content && remaining_lines == 0 {
-                    crossterm::queue!(io::stdout(), terminal::ScrollUp(1))?;
+                    crossterm::queue!(writer, terminal::ScrollUp(1))?;
                     self.position.1 = self.position.1.saturating_sub(1);
                 }
 
-                crossterm::queue!(io::stdout(), cursor::MoveToNextLine(1))?;
+                crossterm::queue!(writer, cursor::MoveToNextLine(1))?;
             }
         }
-        io::stdout().flush()?;
+        writer.flush()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows(count: usize) -> Vec<Vec<StyledGraphemes>> {
+        vec![
+            (0..count)
+                .map(|index| StyledGraphemes::from(format!("row {index}")))
+                .collect(),
+        ]
+    }
+
+    fn command_bytes(command: impl crate::crossterm::Command) -> Vec<u8> {
+        let mut output = Vec::new();
+        crossterm::queue!(output, command).unwrap();
+        output
+    }
+
+    fn command_offset(output: &[u8], command: impl crate::crossterm::Command) -> usize {
+        let command = command_bytes(command);
+        output
+            .windows(command.len())
+            .position(|window| window == command)
+            .expect("expected terminal command was not emitted")
+    }
+
+    #[test]
+    fn growing_frame_scrolls_only_after_clearing_the_previous_frame() {
+        let mut terminal = Terminal { position: (0, 7) };
+        let mut output = Vec::new();
+
+        terminal.draw_rows_to(&mut output, &rows(8), 10).unwrap();
+
+        let clear = command_offset(
+            &output,
+            terminal::Clear(terminal::ClearType::FromCursorDown),
+        );
+        let scroll = command_offset(&output, terminal::ScrollUp(1));
+
+        assert!(clear < scroll);
+        assert_eq!(terminal.position, (0, 2));
+    }
+
+    #[test]
+    fn shrinking_frame_scrolls_preceding_output_back_down_before_redrawing() {
+        let mut terminal = Terminal { position: (0, 7) };
+        terminal
+            .draw_rows_to(&mut Vec::new(), &rows(8), 10)
+            .unwrap();
+        assert_eq!(terminal.position, (0, 2));
+
+        let mut output = Vec::new();
+        terminal.draw_rows_to(&mut output, &rows(3), 10).unwrap();
+
+        let scroll_down = command_offset(&output, terminal::ScrollDown(5));
+        let clear = command_offset(
+            &output,
+            terminal::Clear(terminal::ClearType::FromCursorDown),
+        );
+        let draw = command_offset(&output, cursor::MoveTo(0, 7));
+
+        assert!(scroll_down < clear);
+        assert!(clear < draw);
+        assert_eq!(terminal.position, (0, 7));
+    }
+
+    #[test]
+    fn draw_frame_controls_wrapping_inside_a_synchronized_update() {
+        let mut terminal = Terminal { position: (0, 0) };
+        let mut output = Vec::new();
+
+        terminal.draw_rows_to(&mut output, &rows(1), 10).unwrap();
+
+        let begin = command_offset(&output, terminal::BeginSynchronizedUpdate);
+        let disable_wrap = command_offset(&output, terminal::DisableLineWrap);
+        let enable_wrap = command_offset(&output, terminal::EnableLineWrap);
+        let end = command_offset(&output, terminal::EndSynchronizedUpdate);
+
+        assert!(begin < disable_wrap);
+        assert!(disable_wrap < enable_wrap);
+        assert!(enable_wrap < end);
+    }
+
+    #[test]
+    fn trailing_empty_panes_do_not_trigger_scrolling() {
+        let mut terminal = Terminal { position: (0, 9) };
+        let panes: Vec<Vec<StyledGraphemes>> =
+            vec![vec![StyledGraphemes::from("only row")], Vec::new()];
+
+        terminal.draw_rows_to(&mut Vec::new(), &panes, 10).unwrap();
+
+        assert_eq!(terminal.position, (0, 9));
     }
 }

--- a/promkit-core/src/terminal.rs
+++ b/promkit-core/src/terminal.rs
@@ -11,9 +11,67 @@ use crate::{
 pub struct Terminal {
     /// The current cursor position within the terminal.
     pub position: (u16, u16),
+    anchor: (u16, u16),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DrawPlan {
+    row_count: usize,
+    clear_position: (u16, u16),
+    draw_position: (u16, u16),
+    scroll_down: u16,
+    visible_height: usize,
+    resulting_position: (u16, u16),
+}
+
+impl DrawPlan {
+    fn try_new(
+        row_count: usize,
+        terminal_height: u16,
+        anchor: (u16, u16),
+        position: (u16, u16),
+    ) -> anyhow::Result<Self> {
+        if row_count > terminal_height as usize {
+            return Err(anyhow::anyhow!("Insufficient space to display all panes"));
+        }
+
+        let last_terminal_row = terminal_height.saturating_sub(1);
+        let anchor_row = anchor.1.min(last_terminal_row);
+        let position_row = position.1.min(last_terminal_row);
+        let target_row = if row_count == 0 {
+            anchor_row
+        } else {
+            let row_count =
+                u16::try_from(row_count).expect("row count is bounded by terminal height");
+            anchor_row.min(terminal_height.saturating_sub(row_count))
+        };
+        let scroll_down = target_row.saturating_sub(position_row);
+        let draw_row = position_row.saturating_add(scroll_down);
+
+        Ok(Self {
+            row_count,
+            clear_position: (position.0, draw_row),
+            draw_position: (anchor.0, draw_row),
+            scroll_down,
+            visible_height: terminal_height.saturating_sub(draw_row) as usize,
+            resulting_position: (anchor.0, target_row),
+        })
+    }
+
+    fn scroll_up_after(self, row_index: usize) -> bool {
+        let completed_rows = row_index.saturating_add(1);
+        completed_rows < self.row_count && completed_rows >= self.visible_height.max(1)
+    }
 }
 
 impl Terminal {
+    pub fn new(position: (u16, u16)) -> Self {
+        Self {
+            position,
+            anchor: position,
+        }
+    }
+
     /// Draws content that still needs terminal-width wrapping.
     pub fn draw(&mut self, graphemes: &[StyledGraphemes]) -> anyhow::Result<()> {
         let (width, height) = terminal::size()?;
@@ -46,6 +104,17 @@ impl Terminal {
         R: Borrow<StyledGraphemes>,
     {
         let (_, height) = terminal::size()?;
+        self.draw_rows_at_height(panes, height)
+    }
+
+    pub(crate) fn draw_rows_at_height<R>(
+        &mut self,
+        panes: &[Vec<R>],
+        height: u16,
+    ) -> anyhow::Result<()>
+    where
+        R: Borrow<StyledGraphemes>,
+    {
         let mut stdout = io::stdout();
         self.draw_rows_to(&mut stdout, panes, height)
     }
@@ -60,43 +129,40 @@ impl Terminal {
         W: Write,
         R: Borrow<StyledGraphemes>,
     {
-        let visible_height = height.saturating_sub(self.position.1);
         let row_count = panes.iter().map(Vec::len).sum::<usize>();
-
-        if row_count > height as usize {
-            return Err(anyhow::anyhow!("Insufficient space to display all panes"));
-        }
+        let plan = DrawPlan::try_new(row_count, height, self.anchor, self.position)?;
 
         crossterm::queue!(
             writer,
-            cursor::MoveTo(self.position.0, self.position.1),
+            terminal::BeginSynchronizedUpdate,
+            terminal::DisableLineWrap,
+        )?;
+        if plan.scroll_down > 0 {
+            crossterm::queue!(writer, terminal::ScrollDown(plan.scroll_down))?;
+        }
+        crossterm::queue!(
+            writer,
+            cursor::MoveTo(plan.clear_position.0, plan.clear_position.1),
             terminal::Clear(terminal::ClearType::FromCursorDown),
+            cursor::MoveTo(plan.draw_position.0, plan.draw_position.1),
         )?;
 
-        let mut remaining_lines = visible_height;
+        for (row_index, row) in panes.iter().flatten().enumerate() {
+            crossterm::queue!(writer, style::Print(row.borrow().styled_display()))?;
 
-        for (pane_index, rows) in panes.iter().enumerate() {
-            for (row_index, row) in rows.iter().enumerate() {
-                crossterm::queue!(writer, style::Print(row.borrow().styled_display()))?;
-
-                remaining_lines = remaining_lines.saturating_sub(1);
-
-                // Determine if scrolling is needed:
-                // - We need to scroll if we've reached the bottom of the terminal (remaining_lines == 0)
-                // - AND we have more content to display (either more rows in current pane or more panes)
-                let is_last_pane = pane_index == panes.len() - 1;
-                let is_last_row_in_pane = row_index == rows.len() - 1;
-                let has_more_content = !(is_last_pane && is_last_row_in_pane);
-
-                if has_more_content && remaining_lines == 0 {
-                    crossterm::queue!(writer, terminal::ScrollUp(1))?;
-                    self.position.1 = self.position.1.saturating_sub(1);
-                }
-
-                crossterm::queue!(writer, cursor::MoveToNextLine(1))?;
+            if plan.scroll_up_after(row_index) {
+                crossterm::queue!(writer, terminal::ScrollUp(1))?;
             }
+
+            crossterm::queue!(writer, cursor::MoveToNextLine(1))?;
         }
+        crossterm::queue!(
+            writer,
+            terminal::EnableLineWrap,
+            terminal::EndSynchronizedUpdate
+        )?;
         writer.flush()?;
+        self.position = plan.resulting_position;
         Ok(())
     }
 }
@@ -129,7 +195,7 @@ mod tests {
 
     #[test]
     fn growing_frame_scrolls_only_after_clearing_the_previous_frame() {
-        let mut terminal = Terminal { position: (0, 7) };
+        let mut terminal = Terminal::new((0, 7));
         let mut output = Vec::new();
 
         terminal.draw_rows_to(&mut output, &rows(8), 10).unwrap();
@@ -146,7 +212,7 @@ mod tests {
 
     #[test]
     fn shrinking_frame_scrolls_preceding_output_back_down_before_redrawing() {
-        let mut terminal = Terminal { position: (0, 7) };
+        let mut terminal = Terminal::new((0, 7));
         terminal
             .draw_rows_to(&mut Vec::new(), &rows(8), 10)
             .unwrap();
@@ -160,7 +226,14 @@ mod tests {
             &output,
             terminal::Clear(terminal::ClearType::FromCursorDown),
         );
-        let draw = command_offset(&output, cursor::MoveTo(0, 7));
+        let draw = command_bytes(cursor::MoveTo(0, 7));
+        let draw = output
+            .windows(draw.len())
+            .enumerate()
+            .filter(|(_, window)| *window == draw)
+            .map(|(offset, _)| offset)
+            .nth(1)
+            .expect("expected a move from the clear position to the draw position");
 
         assert!(scroll_down < clear);
         assert!(clear < draw);
@@ -169,7 +242,7 @@ mod tests {
 
     #[test]
     fn draw_frame_controls_wrapping_inside_a_synchronized_update() {
-        let mut terminal = Terminal { position: (0, 0) };
+        let mut terminal = Terminal::new((0, 0));
         let mut output = Vec::new();
 
         terminal.draw_rows_to(&mut output, &rows(1), 10).unwrap();
@@ -186,7 +259,7 @@ mod tests {
 
     #[test]
     fn trailing_empty_panes_do_not_trigger_scrolling() {
-        let mut terminal = Terminal { position: (0, 9) };
+        let mut terminal = Terminal::new((0, 9));
         let panes: Vec<Vec<StyledGraphemes>> =
             vec![vec![StyledGraphemes::from("only row")], Vec::new()];
 

--- a/tests/readline/Cargo.toml
+++ b/tests/readline/Cargo.toml
@@ -10,8 +10,13 @@ promkit = { path = "../../promkit", features = ["readline"] }
 tokio = { workspace = true }
 
 [dev-dependencies]
+portable-pty = "0.9.0"
 termharness = "0.1.0"
 
 [[bin]]
 name = "readline-fixture"
 path = "src/readline_fixture.rs"
+
+[[bin]]
+name = "titled-readline-fixture"
+path = "src/titled_readline_fixture.rs"

--- a/tests/readline/src/titled_readline_fixture.rs
+++ b/tests/readline/src/titled_readline_fixture.rs
@@ -2,6 +2,8 @@ use promkit::{preset::readline::Readline, suggest::Suggest, Prompt};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    println!("Build completed successfully.");
+
     Readline::default()
         .title("Hi!")
         .enable_suggest(Suggest::from_iter([

--- a/tests/readline/src/titled_readline_fixture.rs
+++ b/tests/readline/src/titled_readline_fixture.rs
@@ -1,0 +1,20 @@
+use promkit::{preset::readline::Readline, suggest::Suggest, Prompt};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    Readline::default()
+        .title("Hi!")
+        .enable_suggest(Suggest::from_iter([
+            "apple",
+            "applet",
+            "application",
+            "banana",
+        ]))
+        .validator(
+            |text| text.len() > 10,
+            |text| format!("Length must be over 10 but got {}", text.len()),
+        )
+        .run()
+        .await?;
+    Ok(())
+}

--- a/tests/readline/tests/terminal_scenarios.rs
+++ b/tests/readline/tests/terminal_scenarios.rs
@@ -27,7 +27,35 @@ fn resize_roundtrip_wrap_reflow() -> Result<()> {
 fn titled_long_input_resize_roundtrip_clears_stale_rows() -> Result<()> {
     let command = CommandBuilder::new(env!("CARGO_BIN_EXE_titled-readline-fixture"));
     let mut session = Session::spawn(command, 10, 60, 0, 9)?;
-    thread::sleep(Duration::from_millis(300));
+
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !session
+        .screen_snapshot()
+        .iter()
+        .any(|row| row.starts_with("❯❯"))
+    {
+        assert!(
+            Instant::now() < deadline,
+            "fixture did not render the initial prompt"
+        );
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    assert_eq!(
+        session.screen_snapshot(),
+        vec![
+            "                                                            ",
+            "                                                            ",
+            "                                                            ",
+            "                                                            ",
+            "                                                            ",
+            "                                                            ",
+            "                                                            ",
+            "Build completed successfully.                               ",
+            "Hi!                                                         ",
+            "❯❯                                                          ",
+        ]
+    );
 
     session.write_input(
         b"Terminal prompts should remain stable when the window shrinks and expands again",
@@ -67,7 +95,7 @@ fn titled_long_input_resize_roundtrip_clears_stale_rows() -> Result<()> {
             "                                                            ",
             "                                                            ",
             "                                                            ",
-            "                                                            ",
+            "Build completed successfully.                               ",
             "Hi!                                                         ",
             "❯❯ Terminal prompts should remain stable when the window shr",
             "inks and expands again                                      ",

--- a/tests/readline/tests/terminal_scenarios.rs
+++ b/tests/readline/tests/terminal_scenarios.rs
@@ -1,4 +1,10 @@
-use termharness::{error::Result, scenario};
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
+
+use portable_pty::CommandBuilder;
+use termharness::{error::Result, scenario, session::Session};
 
 #[test]
 fn mid_buffer_insert_wrap() -> Result<()> {
@@ -15,6 +21,60 @@ fn prompt_initial_render_at_mid_screen() -> Result<()> {
 #[test]
 fn resize_roundtrip_wrap_reflow() -> Result<()> {
     run(include_str!("scenarios/resize_roundtrip_wrap_reflow.th"))
+}
+
+#[test]
+fn titled_long_input_resize_roundtrip_clears_stale_rows() -> Result<()> {
+    let command = CommandBuilder::new(env!("CARGO_BIN_EXE_titled-readline-fixture"));
+    let mut session = Session::spawn(command, 10, 60, 0, 9)?;
+    thread::sleep(Duration::from_millis(300));
+
+    session.write_input(
+        b"Terminal prompts should remain stable when the window shrinks and expands again",
+    )?;
+
+    // Start resizing as soon as the fixture begins processing the queued input,
+    // mirroring a fast split-pane divider drag while renders are still in flight.
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !session
+        .output()
+        .windows(b"Terminal".len())
+        .any(|window| window == b"Terminal")
+    {
+        assert!(
+            Instant::now() < deadline,
+            "fixture did not begin rendering the input"
+        );
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    // Intentionally do not settle between widths: the regression depends on
+    // rapid, incremental resize notifications rather than one atomic resize.
+    for cols in (12..60).rev() {
+        session.resize(10, cols)?;
+    }
+    for cols in 13..=60 {
+        session.resize(10, cols)?;
+    }
+    thread::sleep(Duration::from_millis(300));
+
+    assert_eq!(
+        session.screen_snapshot(),
+        vec![
+            "                                                            ",
+            "                                                            ",
+            "                                                            ",
+            "                                                            ",
+            "                                                            ",
+            "                                                            ",
+            "                                                            ",
+            "Hi!                                                         ",
+            "❯❯ Terminal prompts should remain stable when the window shr",
+            "inks and expands again                                      ",
+        ]
+    );
+
+    session.terminate()
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve terminal output immediately preceding a prompt during resize
- make prompt scrolling reversible with paired `ScrollUp` and `ScrollDown`
- prevent terminal auto-wrap from interfering with pre-wrapped renderer rows
- retry rendering after the terminal size stabilizes when a resize races with drawing
- fix trailing empty panes causing unnecessary scrolling

## Test coverage

- add a PTY regression scenario for rapid incremental shrink/expand operations
- verify that preceding terminal output remains directly above the readline
- add unit tests for reversible scrolling, command ordering, synchronized updates, and empty panes
- run the regression scenario successfully 10 consecutive times

## Validation

- `cargo test --workspace -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p promkit-core --lib -- -D warnings`