### PR TITLE
Add configurable terminal session lifecycle management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ members = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 async-trait = "0.1.89"
+bitflags = "2.9.0"
 crossbeam-skiplist = "0.1.3"
 crossterm = { version = "0.29.0", features = ["use-dev-tty", "event-stream", "serde"] }
 csv = "1.3.1"
 futures = "0.3.32"
 radix_trie = "0.3.0"
 rayon = "1.11.0"
-scopeguard = "1.2.0"
 serde = "1.0.228"
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
 serde_yaml = "0.9.34"

--- a/Concept.md
+++ b/Concept.md
@@ -42,9 +42,10 @@ promkit is organized around four responsibilities with clear boundaries:
 1. **Prompt lifecycle runtime (`promkit`)**
    - [`Prompt`](./promkit/src/runtime.rs) defines lifecycle hooks:
      `initialize -> evaluate -> finalize`
-   - [`Prompt::run`](./promkit/src/runtime.rs) manages terminal setup/teardown
-     (raw mode, cursor visibility) and drives input events from a singleton
-     `EVENT_STREAM`.
+   - [`Prompt::run`](./promkit/src/runtime.rs) drives input events from a
+     singleton `EVENT_STREAM`.
+   - `TerminalSession` manages opt-in terminal setup/teardown separately from
+     the prompt lifecycle.
    - Events are processed sequentially.
 
 2. **Application event policy (`examples` and downstream applications)**
@@ -83,7 +84,8 @@ promkit is organized around four responsibilities with clear boundaries:
      after layout is complete.
 
 This keeps responsibilities explicit:
-- runtime = lifecycle and terminal event stream
+- runtime = prompt lifecycle and terminal event stream
+- terminal session = terminal mode lifecycle
 - application prompt = event and focus policy
 - widgets = state to graphemes
 - core renderer = terminal output

--- a/examples/async_task/Cargo.toml
+++ b/examples/async_task/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 promkit = { path = "../../promkit", features = [
     "runtime",
     "spinner",
+    "terminal-session",
     "texteditor",
 ] }
 tokio = { workspace = true }

--- a/examples/async_task/src/async_task.rs
+++ b/examples/async_task/src/async_task.rs
@@ -27,7 +27,7 @@ use promkit::{
         spinner::{self, State},
         text_editor,
     },
-    Prompt, Signal,
+    Prompt, Signal, TerminalModes, TerminalSession,
 };
 use tokio::{
     sync::{mpsc, RwLock},
@@ -427,5 +427,8 @@ impl AsyncTaskPrompt {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let modes =
+        TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+    let _terminal_session = TerminalSession::try_new(modes)?;
     AsyncTaskPrompt::try_default().await?.spawn().await
 }

--- a/examples/checkbox/Cargo.toml
+++ b/examples/checkbox/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-promkit = { path = "../../promkit", features = ["runtime", "checkbox", "text"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "checkbox", "text"] }
 tokio = { workspace = true }
 
 [[bin]]

--- a/examples/checkbox/src/checkbox.rs
+++ b/examples/checkbox/src/checkbox.rs
@@ -14,7 +14,7 @@ use promkit::{
         checkbox::{self, Checkbox, CheckboxHit},
         text::{self, Text},
     },
-    Prompt, Signal,
+    Prompt, Signal, TerminalModes, TerminalSession,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -185,20 +185,25 @@ impl Prompt for CheckboxPrompt {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let ret = CheckboxPrompt::new([
-        "Apple",
-        "Banana",
-        "Orange",
-        "Mango",
-        "Strawberry",
-        "Pineapple",
-        "Grape",
-        "Watermelon",
-        "Kiwi",
-        "Pear",
-    ])
-    .run()
-    .await?;
+    let ret = {
+        let modes =
+            TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+        let _terminal_session = TerminalSession::try_new(modes)?;
+        CheckboxPrompt::new([
+            "Apple",
+            "Banana",
+            "Orange",
+            "Mango",
+            "Strawberry",
+            "Pineapple",
+            "Grape",
+            "Watermelon",
+            "Kiwi",
+            "Pear",
+        ])
+        .run()
+        .await?
+    };
     println!("result: {:?}", ret);
     Ok(())
 }

--- a/examples/confirm/Cargo.toml
+++ b/examples/confirm/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-promkit = { path = "../../promkit", features = ["runtime", "validate"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "validate"] }
 readline-example = { package = "readline", path = "../readline" }
 tokio = { workspace = true }
 

--- a/examples/confirm/src/confirm.rs
+++ b/examples/confirm/src/confirm.rs
@@ -1,4 +1,4 @@
-use promkit::{validate::ValidatorManager, Prompt};
+use promkit::{validate::ValidatorManager, Prompt, TerminalModes, TerminalSession};
 use readline_example::Readline;
 
 #[tokio::main]
@@ -10,7 +10,12 @@ async fn main() -> anyhow::Result<()> {
         |_| "Please type 'y' or 'n' as an answer".into(),
     ));
 
-    let ret = prompt.run().await?;
+    let ret = {
+        let modes =
+            TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+        let _terminal_session = TerminalSession::try_new(modes)?;
+        prompt.run().await?
+    };
     println!("result: {:?}", ret);
     Ok(())
 }

--- a/examples/csv/Cargo.toml
+++ b/examples/csv/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4.5.60", features = ["derive"] }
-promkit = { path = "../../promkit", features = ["runtime", "table"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "table"] }
 tokio = { workspace = true }
 
 [[bin]]

--- a/examples/csv/src/csv.rs
+++ b/examples/csv/src/csv.rs
@@ -5,16 +5,16 @@ use promkit::{
     core::{
         crossterm::{
             event::{
-                self, Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
-                MouseEvent, MouseEventKind,
+                Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent,
+                MouseEventKind,
             },
-            execute, terminal,
+            terminal,
         },
         render::{Renderer, SharedRenderer},
         Widget,
     },
     widgets::table::{CsvOptions, Document, State},
-    Prompt, Signal,
+    Prompt, Signal, TerminalModes, TerminalSession,
 };
 
 /// Interactive CSV viewer powered by promkit.
@@ -202,30 +202,16 @@ fn parse_document(args: &Args) -> anyhow::Result<Document> {
     }
 }
 
-/// Ensure the terminal is restored to its original state when dropped.
-struct TerminalGuard;
-
-impl Drop for TerminalGuard {
-    fn drop(&mut self) {
-        let _ = execute!(
-            io::stdout(),
-            terminal::LeaveAlternateScreen,
-            event::DisableMouseCapture
-        );
-    }
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let document = parse_document(&args)?;
 
-    execute!(
-        io::stdout(),
-        terminal::EnterAlternateScreen,
-        event::EnableMouseCapture
-    )?;
-    let _terminal_guard = TerminalGuard;
+    let modes = TerminalModes::RAW_MODE
+        | TerminalModes::ALTERNATE_SCREEN
+        | TerminalModes::HIDDEN_CURSOR
+        | TerminalModes::MOUSE_CAPTURE;
+    let _terminal_session = TerminalSession::try_new(modes)?;
 
     CsvViewer::new(document).run().await
 }

--- a/examples/form/Cargo.toml
+++ b/examples/form/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-promkit = { path = "../../promkit", features = ["runtime", "texteditor"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "texteditor"] }
 tokio = { workspace = true }
 
 [[bin]]

--- a/examples/form/src/form.rs
+++ b/examples/form/src/form.rs
@@ -11,7 +11,7 @@ use promkit::{
         ScreenPosition, Widget,
     },
     widgets::text_editor::{self, TextEditorHit},
-    Prompt, Signal,
+    Prompt, Signal, TerminalModes, TerminalSession,
 };
 
 #[derive(Clone, Copy)]
@@ -258,13 +258,18 @@ fn field(prefix_color: Color) -> text_editor::State {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let ret = Form::new([
-        field(Color::DarkRed),
-        field(Color::DarkGreen),
-        field(Color::DarkBlue),
-    ])
-    .run()
-    .await?;
+    let ret = {
+        let modes =
+            TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+        let _terminal_session = TerminalSession::try_new(modes)?;
+        Form::new([
+            field(Color::DarkRed),
+            field(Color::DarkGreen),
+            field(Color::DarkBlue),
+        ])
+        .run()
+        .await?
+    };
     println!("result: {:?}", ret);
     Ok(())
 }

--- a/examples/json/Cargo.toml
+++ b/examples/json/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4.5.60", features = ["derive"] }
-promkit = { path = "../../promkit", features = ["runtime", "json", "text"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "json", "text"] }
 tokio = { workspace = true }
 
 [[bin]]

--- a/examples/json/src/json.rs
+++ b/examples/json/src/json.rs
@@ -9,10 +9,9 @@ use promkit::{
     core::{
         crossterm::{
             event::{
-                self, Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
-                MouseButton, MouseEvent, MouseEventKind,
+                Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+                MouseEvent, MouseEventKind,
             },
-            execute,
             style::{Attribute, Attributes, Color, ContentStyle},
             terminal,
         },
@@ -23,7 +22,7 @@ use promkit::{
         json::{self, config::OverflowMode, Document, JsonHit},
         text::{self, Text},
     },
-    Prompt, Signal,
+    Prompt, Signal, TerminalModes, TerminalSession,
 };
 
 /// Interactive JSON viewer powered by promkit.
@@ -225,30 +224,16 @@ impl Prompt for JsonViewer {
     }
 }
 
-/// Ensure the terminal is restored to its original state when dropped.
-struct TerminalGuard;
-
-impl Drop for TerminalGuard {
-    fn drop(&mut self) {
-        let _ = execute!(
-            io::stdout(),
-            terminal::LeaveAlternateScreen,
-            event::DisableMouseCapture
-        );
-    }
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let document = parse_document(&args)?;
 
-    execute!(
-        io::stdout(),
-        terminal::EnterAlternateScreen,
-        event::EnableMouseCapture
-    )?;
-    let _terminal_guard = TerminalGuard;
+    let modes = TerminalModes::RAW_MODE
+        | TerminalModes::ALTERNATE_SCREEN
+        | TerminalModes::HIDDEN_CURSOR
+        | TerminalModes::MOUSE_CAPTURE;
+    let _terminal_session = TerminalSession::try_new(modes)?;
 
     JsonViewer::new(document).run().await
 }

--- a/examples/listbox/Cargo.toml
+++ b/examples/listbox/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-promkit = { path = "../../promkit", features = ["runtime", "listbox", "text"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "listbox", "text"] }
 tokio = { workspace = true }
 
 [[bin]]

--- a/examples/listbox/src/listbox.rs
+++ b/examples/listbox/src/listbox.rs
@@ -14,7 +14,7 @@ use promkit::{
         listbox::{self, Listbox, ListboxHit},
         text::{self, Text},
     },
-    Prompt, Signal,
+    Prompt, Signal, TerminalModes, TerminalSession,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -169,7 +169,12 @@ impl Prompt for ListboxPrompt {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let ret = ListboxPrompt::new(0..100).run().await?;
+    let ret = {
+        let modes =
+            TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+        let _terminal_session = TerminalSession::try_new(modes)?;
+        ListboxPrompt::new(0..100).run().await?
+    };
     println!("result: {:?}", ret);
     Ok(())
 }

--- a/examples/password/Cargo.toml
+++ b/examples/password/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-promkit = { path = "../../promkit", features = ["runtime", "validate", "text"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "validate", "text"] }
 readline-example = { package = "readline", path = "../readline" }
 tokio = { workspace = true }
 

--- a/examples/password/src/password.rs
+++ b/examples/password/src/password.rs
@@ -1,4 +1,6 @@
-use promkit::{validate::ValidatorManager, widgets::text::Text, Prompt};
+use promkit::{
+    validate::ValidatorManager, widgets::text::Text, Prompt, TerminalModes, TerminalSession,
+};
 use readline_example::Readline;
 
 #[tokio::main]
@@ -11,7 +13,12 @@ async fn main() -> anyhow::Result<()> {
         |text| format!("Length must be over 4 and within 10 but got {}", text.len()),
     ));
 
-    let ret = prompt.run().await?;
+    let ret = {
+        let modes =
+            TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+        let _terminal_session = TerminalSession::try_new(modes)?;
+        prompt.run().await?
+    };
     println!("result: {:?}", ret);
     Ok(())
 }

--- a/examples/query_selector/Cargo.toml
+++ b/examples/query_selector/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 promkit = { path = "../../promkit", features = [
     "runtime",
     "listbox",
+    "terminal-session",
     "text",
     "texteditor",
 ] }

--- a/examples/query_selector/src/query_selector.rs
+++ b/examples/query_selector/src/query_selector.rs
@@ -15,7 +15,7 @@ use promkit::{
         text::{self, Text},
         text_editor::{self, TextEditorHit},
     },
-    Prompt, Signal,
+    Prompt, Signal, TerminalModes, TerminalSession,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -239,19 +239,24 @@ impl Prompt for QuerySelector {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let ret = QuerySelector::new(0..100, |text, items| {
-        text.parse::<usize>()
-            .map(|query| {
-                items
-                    .iter()
-                    .filter(|item| query <= item.parse::<usize>().unwrap_or_default())
-                    .cloned()
-                    .collect()
-            })
-            .unwrap_or_else(|_| items.to_vec())
-    })
-    .run()
-    .await?;
+    let ret = {
+        let modes =
+            TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+        let _terminal_session = TerminalSession::try_new(modes)?;
+        QuerySelector::new(0..100, |text, items| {
+            text.parse::<usize>()
+                .map(|query| {
+                    items
+                        .iter()
+                        .filter(|item| query <= item.parse::<usize>().unwrap_or_default())
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_else(|_| items.to_vec())
+        })
+        .run()
+        .await?
+    };
     println!("result: {:?}", ret);
     Ok(())
 }

--- a/examples/readline/Cargo.toml
+++ b/examples/readline/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 anyhow = { workspace = true }
 promkit = { path = "../../promkit", features = [
     "runtime",
+    "terminal-session",
     "validate",
     "prefixsearch",
     "text",

--- a/examples/readline/src/readline.rs
+++ b/examples/readline/src/readline.rs
@@ -1,7 +1,7 @@
 use promkit::{
     validate::ValidatorManager,
     widgets::{prefix_search::PrefixSearch, text::Text},
-    Prompt,
+    Prompt, TerminalModes, TerminalSession,
 };
 use readline::Readline;
 
@@ -16,7 +16,12 @@ async fn main() -> anyhow::Result<()> {
         |text| format!("Length must be over 10 but got {}", text.len()),
     ));
 
-    let ret = prompt.run().await?;
+    let ret = {
+        let modes =
+            TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+        let _terminal_session = TerminalSession::try_new(modes)?;
+        prompt.run().await?
+    };
     println!("result: {:?}", ret);
     Ok(())
 }

--- a/examples/repl/Cargo.toml
+++ b/examples/repl/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 futures = { workspace = true }
+promkit = { path = "../../promkit", features = ["terminal-session"] }
 promkit-widgets = { path = "../../promkit-widgets", features = ["texteditor"] }
 tokio = { workspace = true }
 

--- a/examples/repl/src/repl.rs
+++ b/examples/repl/src/repl.rs
@@ -3,17 +3,16 @@
 use std::{collections::HashSet, io};
 
 use futures::StreamExt;
+use promkit::{TerminalModes, TerminalSession};
 use promkit_widgets::{
     core::{
         crossterm::{
-            cursor,
             event::{
-                self, Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyEventState,
-                KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+                Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
+                MouseButton, MouseEvent, MouseEventKind,
             },
             execute,
             style::{Color, ContentStyle, Print},
-            terminal::{disable_raw_mode, enable_raw_mode},
         },
         render::{Renderer, SharedRenderer},
         ScreenPosition, Widget,
@@ -39,15 +38,6 @@ enum Control {
     Continue,
     Submit(String),
     Exit,
-}
-
-struct TerminalGuard;
-
-impl Drop for TerminalGuard {
-    fn drop(&mut self) {
-        execute!(io::stdout(), cursor::Show, event::DisableMouseCapture,).ok();
-        disable_raw_mode().ok();
-    }
 }
 
 struct Repl {
@@ -305,14 +295,13 @@ impl Repl {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    enable_raw_mode()?;
+    let modes =
+        TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+    let _terminal_session = TerminalSession::try_new(modes)?;
     execute!(
         io::stdout(),
-        cursor::Hide,
-        event::EnableMouseCapture,
         Print("Bracket REPL (blank: submit, \"exit\": quit)\r\n"),
     )?;
-    let _terminal_guard = TerminalGuard;
     let mut events = EventStream::new();
 
     loop {

--- a/examples/text/Cargo.toml
+++ b/examples/text/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-promkit = { path = "../../promkit", features = ["runtime", "text"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "text"] }
 tokio = { workspace = true }
 
 [[bin]]

--- a/examples/text/src/text.rs
+++ b/examples/text/src/text.rs
@@ -8,7 +8,7 @@ use promkit::{
         ScreenPosition, Widget,
     },
     widgets::text::{self, Text, TextHit},
-    Prompt, Signal,
+    Prompt, Signal, TerminalModes, TerminalSession,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -138,6 +138,9 @@ impl Prompt for TextPrompt {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let modes =
+        TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+    let _terminal_session = TerminalSession::try_new(modes)?;
     TextPrompt::new(std::fs::read_to_string("Cargo.toml")?)
         .run()
         .await

--- a/examples/tree/Cargo.toml
+++ b/examples/tree/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-promkit = { path = "../../promkit", features = ["runtime", "tree", "text"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "tree", "text"] }
 tokio = { workspace = true }
 
 [[bin]]

--- a/examples/tree/src/tree.rs
+++ b/examples/tree/src/tree.rs
@@ -16,7 +16,7 @@ use promkit::{
         structured::tree::{self, Document, TreeHit},
         text::{self, Text},
     },
-    Prompt, Signal,
+    Prompt, Signal, TerminalModes, TerminalSession,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -182,7 +182,12 @@ impl Prompt for TreePrompt {
 async fn main() -> anyhow::Result<()> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../promkit/src");
     let document = Document::from_path(&root)?;
-    let ret = TreePrompt::new(document).run().await?;
+    let ret = {
+        let modes =
+            TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+        let _terminal_session = TerminalSession::try_new(modes)?;
+        TreePrompt::new(document).run().await?
+    };
     println!("result: {:?}", ret);
     Ok(())
 }

--- a/examples/yaml/Cargo.toml
+++ b/examples/yaml/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4.5.60", features = ["derive"] }
-promkit = { path = "../../promkit", features = ["runtime", "yaml", "text"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "yaml", "text"] }
 tokio = { workspace = true }
 
 [[bin]]

--- a/examples/yaml/src/yaml.rs
+++ b/examples/yaml/src/yaml.rs
@@ -9,10 +9,9 @@ use promkit::{
     core::{
         crossterm::{
             event::{
-                self, Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
-                MouseButton, MouseEvent, MouseEventKind,
+                Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+                MouseEvent, MouseEventKind,
             },
-            execute,
             style::{Attribute, Attributes, Color, ContentStyle},
             terminal,
         },
@@ -23,7 +22,7 @@ use promkit::{
         text::{self, Text},
         yaml::{self, config::OverflowMode, Document, YamlHit},
     },
-    Prompt, Signal,
+    Prompt, Signal, TerminalModes, TerminalSession,
 };
 
 /// Interactive YAML viewer powered by promkit.
@@ -229,30 +228,16 @@ impl Prompt for YamlViewer {
     }
 }
 
-/// Ensure the terminal is restored to its original state when dropped.
-struct TerminalGuard;
-
-impl Drop for TerminalGuard {
-    fn drop(&mut self) {
-        let _ = execute!(
-            io::stdout(),
-            terminal::LeaveAlternateScreen,
-            event::DisableMouseCapture
-        );
-    }
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let document = parse_document(&args)?;
 
-    execute!(
-        io::stdout(),
-        terminal::EnterAlternateScreen,
-        event::EnableMouseCapture
-    )?;
-    let _terminal_guard = TerminalGuard;
+    let modes = TerminalModes::RAW_MODE
+        | TerminalModes::ALTERNATE_SCREEN
+        | TerminalModes::HIDDEN_CURSOR
+        | TerminalModes::MOUSE_CAPTURE;
+    let _terminal_session = TerminalSession::try_new(modes)?;
 
     YamlViewer::new(document).run().await
 }

--- a/promkit/Cargo.toml
+++ b/promkit/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 default = []
 all = [
     "runtime",
+    "terminal-session",
     "validate",
     "prefixsearch",
     "checkbox",
@@ -39,9 +40,9 @@ runtime = [
     "dep:anyhow",
     "dep:async-trait",
     "dep:futures",
-    "dep:scopeguard",
     "dep:tokio",
 ]
+terminal-session = ["dep:bitflags", "dep:crossterm"]
 widgets = ["core", "dep:promkit-widgets"]
 
 # Capabilities
@@ -64,10 +65,11 @@ tree = ["widgets", "promkit-widgets/tree"]
 [dependencies]
 anyhow = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
+bitflags = { workspace = true, optional = true }
+crossterm = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 promkit-core = { path = "../promkit-core", version = "=0.5.0", optional = true }
 promkit-widgets = { path = "../promkit-widgets", version = "=0.7.0", default-features = false, optional = true }
-scopeguard = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]

--- a/promkit/src/lib.rs
+++ b/promkit/src/lib.rs
@@ -17,3 +17,8 @@ pub mod validate;
 mod runtime;
 #[cfg(feature = "runtime")]
 pub use runtime::{Prompt, Signal, EVENT_STREAM};
+
+#[cfg(feature = "terminal-session")]
+mod terminal_session;
+#[cfg(feature = "terminal-session")]
+pub use terminal_session::{TerminalModes, TerminalSession};

--- a/promkit/src/runtime.rs
+++ b/promkit/src/runtime.rs
@@ -1,21 +1,16 @@
 //! A small lifecycle runtime for sequential, interactive prompts.
 //!
-//! This module owns terminal setup, teardown, and event delivery. Applications
-//! remain responsible for composing widgets, mapping events to state changes,
-//! rendering updates, focus management, validation, and quit policy.
+//! This module owns prompt lifecycle and event delivery. Applications remain
+//! responsible for terminal setup and teardown, composing widgets, mapping
+//! events to state changes, rendering updates, focus management, validation,
+//! and quit policy.
 
-use std::{io, sync::LazyLock};
+use std::sync::LazyLock;
 
 use futures::StreamExt;
-use scopeguard::defer;
 use tokio::sync::Mutex;
 
-use crate::core::crossterm::{
-    cursor,
-    event::{self, Event, EventStream},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode},
-};
+use crate::core::crossterm::event::{Event, EventStream};
 
 /// The singleton terminal event stream used by [`Prompt::run`].
 ///
@@ -57,13 +52,11 @@ pub enum Signal {
 pub trait Prompt {
     /// Prepares the prompt before terminal events are evaluated.
     ///
-    /// [`Prompt::run`] calls this after enabling raw mode, hiding the cursor,
-    /// and enabling mouse capture. Implementations commonly initialize their
-    /// renderer and draw the initial prompt here.
+    /// Implementations commonly initialize their renderer and draw the initial
+    /// prompt here.
     ///
     /// If this method returns an error, the error is propagated and
-    /// [`Prompt::finalize`] is not called. Terminal modes configured by
-    /// [`Prompt::run`] are still restored.
+    /// [`Prompt::finalize`] is not called.
     async fn initialize(&mut self) -> anyhow::Result<()>;
 
     /// Applies one terminal event to the application-owned prompt state.
@@ -94,47 +87,26 @@ pub trait Prompt {
     ///
     /// This method:
     ///
-    /// 1. enables raw mode, hides the cursor, and enables mouse capture;
-    /// 2. calls [`Prompt::initialize`];
-    /// 3. reads events from [`EVENT_STREAM`] and passes non-resize events to
+    /// 1. calls [`Prompt::initialize`];
+    /// 2. reads events from [`EVENT_STREAM`] and passes non-resize events to
     ///    [`Prompt::evaluate`] until it returns [`Signal::Quit`];
-    /// 4. calls [`Prompt::finalize`]; and
-    /// 5. restores cursor visibility, disables mouse capture, and disables raw
-    ///    mode.
-    ///
-    /// Terminal restoration is attempted when the method exits, including
-    /// error paths. Restoration errors are ignored so that an earlier prompt
-    /// error is preserved.
+    /// 3. calls [`Prompt::finalize`].
     ///
     /// # Runtime scope
     ///
-    /// The runtime writes terminal commands to standard output and processes
-    /// one prompt sequentially. It does not enter or leave the alternate
-    /// screen, redraw immediately on resize, multiplex application events, or
-    /// coordinate concurrent prompts. Applications that need those policies
-    /// should own their event loop and use `promkit-core` and
-    /// `promkit-widgets` directly.
+    /// The runtime processes one prompt sequentially. It does not configure or
+    /// restore terminal modes, redraw immediately on resize, multiplex
+    /// application events, or coordinate concurrent prompts. Callers are
+    /// responsible for the terminal lifecycle and can use `TerminalSession`
+    /// when the `terminal-session` feature is enabled.
     ///
     /// # Errors
     ///
-    /// Returns errors from terminal setup, [`Prompt::initialize`],
-    /// [`Prompt::evaluate`], or [`Prompt::finalize`]. An error yielded by the
-    /// terminal event stream ends the loop and is not propagated; in that case,
-    /// [`Prompt::finalize`] determines the result.
+    /// Returns errors from [`Prompt::initialize`], [`Prompt::evaluate`], or
+    /// [`Prompt::finalize`]. An error yielded by the terminal event stream ends
+    /// the loop and is not propagated; in that case, [`Prompt::finalize`]
+    /// determines the result.
     async fn run(&mut self) -> anyhow::Result<Self::Return> {
-        defer! {
-            execute!(
-                io::stdout(),
-                cursor::Show,
-                event::DisableMouseCapture,
-            )
-            .ok();
-            disable_raw_mode().ok();
-        };
-
-        enable_raw_mode()?;
-        execute!(io::stdout(), cursor::Hide, event::EnableMouseCapture)?;
-
         self.initialize().await?;
 
         while let Some(event) = EVENT_STREAM.lock().await.next().await {

--- a/promkit/src/terminal_session.rs
+++ b/promkit/src/terminal_session.rs
@@ -7,10 +7,7 @@ use crossterm::{
     cursor,
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{
-        disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, EnterAlternateScreen,
-        LeaveAlternateScreen,
-    },
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 
 bitflags! {
@@ -63,8 +60,7 @@ fn crossterm_backend(operation: Operation) -> io::Result<()> {
 /// unwinding.
 ///
 /// If setup fails partway through, all modes whose setup was attempted are
-/// restored before the setup error is returned. Raw mode is not disabled if it
-/// was already enabled before the session started.
+/// restored before the setup error is returned.
 ///
 /// # Example
 ///
@@ -93,14 +89,10 @@ impl TerminalSession {
     /// then mouse capture. If a step returns an error or unwinds, [`Drop`]
     /// attempts to reverse every step that had started.
     pub fn try_new(modes: TerminalModes) -> io::Result<Self> {
-        Self::try_new_with(crossterm_backend, modes, is_raw_mode_enabled()?)
+        Self::try_new_with(crossterm_backend, modes)
     }
 
-    fn try_new_with(
-        backend: Backend,
-        modes: TerminalModes,
-        raw_mode_was_enabled: bool,
-    ) -> io::Result<Self> {
+    fn try_new_with(backend: Backend, modes: TerminalModes) -> io::Result<Self> {
         let mut session = Self {
             backend,
             pending_restore: TerminalModes::empty(),
@@ -115,7 +107,7 @@ impl TerminalSession {
             (TerminalModes::HIDDEN_CURSOR, Operation::HideCursor),
             (TerminalModes::MOUSE_CAPTURE, Operation::EnableMouseCapture),
         ] {
-            if !modes.contains(mode) || (mode == TerminalModes::RAW_MODE && raw_mode_was_enabled) {
+            if !modes.contains(mode) {
                 continue;
             }
 
@@ -223,7 +215,7 @@ mod tests {
     }
 
     fn try_new(modes: TerminalModes) -> io::Result<TerminalSession> {
-        TerminalSession::try_new_with(mock_backend, modes, false)
+        TerminalSession::try_new_with(mock_backend, modes)
     }
 
     #[test]
@@ -310,7 +302,7 @@ mod tests {
             | TerminalModes::HIDDEN_CURSOR
             | TerminalModes::MOUSE_CAPTURE;
         let panic = std::panic::catch_unwind(|| {
-            TerminalSession::try_new_with(panicking_backend, modes, false).ok();
+            TerminalSession::try_new_with(panicking_backend, modes).ok();
         });
 
         assert!(panic.is_err());
@@ -369,30 +361,6 @@ mod tests {
                 Operation::EnterAlternateScreen,
                 Operation::EnableMouseCapture,
                 Operation::DisableMouseCapture,
-                Operation::LeaveAlternateScreen,
-            ]
-        );
-    }
-
-    #[test]
-    fn preserves_raw_mode_that_was_already_enabled() {
-        reset([]);
-
-        let modes = TerminalModes::RAW_MODE
-            | TerminalModes::ALTERNATE_SCREEN
-            | TerminalModes::HIDDEN_CURSOR
-            | TerminalModes::MOUSE_CAPTURE;
-        let mut session = TerminalSession::try_new_with(mock_backend, modes, true).unwrap();
-        session.restore().unwrap();
-
-        assert_eq!(
-            operations(),
-            [
-                Operation::EnterAlternateScreen,
-                Operation::HideCursor,
-                Operation::EnableMouseCapture,
-                Operation::DisableMouseCapture,
-                Operation::ShowCursor,
                 Operation::LeaveAlternateScreen,
             ]
         );

--- a/promkit/src/terminal_session.rs
+++ b/promkit/src/terminal_session.rs
@@ -1,0 +1,400 @@
+//! Terminal lifecycle management for interactive applications.
+
+use std::io;
+
+use bitflags::bitflags;
+use crossterm::{
+    cursor,
+    event::{DisableMouseCapture, EnableMouseCapture},
+    execute,
+    terminal::{
+        disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, EnterAlternateScreen,
+        LeaveAlternateScreen,
+    },
+};
+
+bitflags! {
+    /// Terminal modes managed by a [`TerminalSession`].
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+    pub struct TerminalModes: u8 {
+        /// Enables raw mode.
+        const RAW_MODE = 1 << 0;
+        /// Enters the alternate screen.
+        const ALTERNATE_SCREEN = 1 << 1;
+        /// Hides the cursor.
+        const HIDDEN_CURSOR = 1 << 2;
+        /// Enables mouse capture.
+        const MOUSE_CAPTURE = 1 << 3;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Operation {
+    EnableRawMode,
+    EnterAlternateScreen,
+    HideCursor,
+    EnableMouseCapture,
+    DisableMouseCapture,
+    ShowCursor,
+    LeaveAlternateScreen,
+    DisableRawMode,
+}
+
+type Backend = fn(Operation) -> io::Result<()>;
+
+fn crossterm_backend(operation: Operation) -> io::Result<()> {
+    match operation {
+        Operation::EnableRawMode => enable_raw_mode(),
+        Operation::EnterAlternateScreen => execute!(io::stdout(), EnterAlternateScreen),
+        Operation::HideCursor => execute!(io::stdout(), cursor::Hide),
+        Operation::EnableMouseCapture => execute!(io::stdout(), EnableMouseCapture),
+        Operation::DisableMouseCapture => execute!(io::stdout(), DisableMouseCapture),
+        Operation::ShowCursor => execute!(io::stdout(), cursor::Show),
+        Operation::LeaveAlternateScreen => execute!(io::stdout(), LeaveAlternateScreen),
+        Operation::DisableRawMode => disable_raw_mode(),
+    }
+}
+
+/// Owns configured terminal modes for the duration of an interactive session.
+///
+/// [`TerminalSession::try_new`] applies the requested [`TerminalModes`].
+/// [`TerminalSession::restore`] reverses them, and restoration is also attempted
+/// automatically when the session is dropped, including during panic
+/// unwinding.
+///
+/// If setup fails partway through, all modes whose setup was attempted are
+/// restored before the setup error is returned. Raw mode is not disabled if it
+/// was already enabled before the session started.
+///
+/// # Example
+///
+/// ```no_run
+/// use promkit::{TerminalModes, TerminalSession};
+///
+/// # fn run() -> std::io::Result<()> {
+/// let modes = TerminalModes::RAW_MODE
+///     | TerminalModes::HIDDEN_CURSOR
+///     | TerminalModes::MOUSE_CAPTURE;
+/// let _session = TerminalSession::try_new(modes)?;
+/// // Run the application's event loop.
+/// # Ok(())
+/// # }
+/// ```
+#[must_use = "dropping the session immediately restores the terminal"]
+pub struct TerminalSession {
+    backend: Backend,
+    pending_restore: TerminalModes,
+}
+
+impl TerminalSession {
+    /// Applies `modes` and starts a terminal session.
+    ///
+    /// Setup follows a fixed order: raw mode, alternate screen, hidden cursor,
+    /// then mouse capture. If a step returns an error or unwinds, [`Drop`]
+    /// attempts to reverse every step that had started.
+    pub fn try_new(modes: TerminalModes) -> io::Result<Self> {
+        Self::try_new_with(crossterm_backend, modes, is_raw_mode_enabled()?)
+    }
+
+    fn try_new_with(
+        backend: Backend,
+        modes: TerminalModes,
+        raw_mode_was_enabled: bool,
+    ) -> io::Result<Self> {
+        let mut session = Self {
+            backend,
+            pending_restore: TerminalModes::empty(),
+        };
+
+        for (mode, operation) in [
+            (TerminalModes::RAW_MODE, Operation::EnableRawMode),
+            (
+                TerminalModes::ALTERNATE_SCREEN,
+                Operation::EnterAlternateScreen,
+            ),
+            (TerminalModes::HIDDEN_CURSOR, Operation::HideCursor),
+            (TerminalModes::MOUSE_CAPTURE, Operation::EnableMouseCapture),
+        ] {
+            if !modes.contains(mode) || (mode == TerminalModes::RAW_MODE && raw_mode_was_enabled) {
+                continue;
+            }
+
+            // Record the inverse before setup so Drop also covers a panic or a
+            // partially applied terminal command.
+            session.pending_restore.insert(mode);
+            (session.backend)(operation)?;
+        }
+
+        Ok(session)
+    }
+
+    /// Restores the terminal modes owned by this session.
+    ///
+    /// Every pending restoration is attempted even if an earlier one fails.
+    /// The first error is returned. Successfully restored modes are removed, so
+    /// a later call or [`Drop`] retries only failed restorations.
+    pub fn restore(&mut self) -> io::Result<()> {
+        let mut first_error = None;
+
+        for (mode, operation) in [
+            (TerminalModes::MOUSE_CAPTURE, Operation::DisableMouseCapture),
+            (TerminalModes::HIDDEN_CURSOR, Operation::ShowCursor),
+            (
+                TerminalModes::ALTERNATE_SCREEN,
+                Operation::LeaveAlternateScreen,
+            ),
+            (TerminalModes::RAW_MODE, Operation::DisableRawMode),
+        ] {
+            if !self.pending_restore.contains(mode) {
+                continue;
+            }
+
+            match (self.backend)(operation) {
+                Ok(()) => self.pending_restore.remove(mode),
+                Err(error) if first_error.is_none() => first_error = Some(error),
+                Err(_) => {}
+            }
+        }
+
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for TerminalSession {
+    fn drop(&mut self) {
+        self.restore().ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        cell::RefCell,
+        collections::VecDeque,
+        io::{self, ErrorKind},
+    };
+
+    use super::{Operation, TerminalModes, TerminalSession};
+
+    #[derive(Default)]
+    struct MockState {
+        operations: Vec<Operation>,
+        failures: VecDeque<Operation>,
+    }
+
+    thread_local! {
+        static MOCK_STATE: RefCell<MockState> = RefCell::new(MockState::default());
+    }
+
+    fn mock_backend(operation: Operation) -> io::Result<()> {
+        MOCK_STATE.with_borrow_mut(|state| {
+            state.operations.push(operation);
+            if state.failures.front() == Some(&operation) {
+                state.failures.pop_front();
+                Err(io::Error::other("terminal operation failed"))
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    fn panicking_backend(operation: Operation) -> io::Result<()> {
+        if operation == Operation::HideCursor {
+            MOCK_STATE.with_borrow_mut(|state| state.operations.push(operation));
+            panic!("terminal operation panicked");
+        }
+        mock_backend(operation)
+    }
+
+    fn reset(failures: impl IntoIterator<Item = Operation>) {
+        MOCK_STATE.with_borrow_mut(|state| {
+            *state = MockState {
+                failures: failures.into_iter().collect(),
+                ..MockState::default()
+            };
+        });
+    }
+
+    fn operations() -> Vec<Operation> {
+        MOCK_STATE.with_borrow(|state| state.operations.clone())
+    }
+
+    fn try_new(modes: TerminalModes) -> io::Result<TerminalSession> {
+        TerminalSession::try_new_with(mock_backend, modes, false)
+    }
+
+    #[test]
+    fn restores_fullscreen_modes_in_reverse_order() {
+        reset([]);
+
+        let modes = TerminalModes::RAW_MODE
+            | TerminalModes::ALTERNATE_SCREEN
+            | TerminalModes::HIDDEN_CURSOR
+            | TerminalModes::MOUSE_CAPTURE;
+        let mut session = try_new(modes).unwrap();
+        session.restore().unwrap();
+        session.restore().unwrap();
+
+        assert_eq!(
+            operations(),
+            [
+                Operation::EnableRawMode,
+                Operation::EnterAlternateScreen,
+                Operation::HideCursor,
+                Operation::EnableMouseCapture,
+                Operation::DisableMouseCapture,
+                Operation::ShowCursor,
+                Operation::LeaveAlternateScreen,
+                Operation::DisableRawMode,
+            ]
+        );
+    }
+
+    #[test]
+    fn restores_terminal_when_dropped() {
+        reset([]);
+
+        {
+            let modes = TerminalModes::RAW_MODE
+                | TerminalModes::HIDDEN_CURSOR
+                | TerminalModes::MOUSE_CAPTURE;
+            let _session = try_new(modes).unwrap();
+        }
+
+        assert_eq!(
+            operations(),
+            [
+                Operation::EnableRawMode,
+                Operation::HideCursor,
+                Operation::EnableMouseCapture,
+                Operation::DisableMouseCapture,
+                Operation::ShowCursor,
+                Operation::DisableRawMode,
+            ]
+        );
+    }
+
+    #[test]
+    fn rolls_back_attempted_setup_when_setup_fails() {
+        reset([Operation::HideCursor]);
+
+        let modes = TerminalModes::RAW_MODE
+            | TerminalModes::ALTERNATE_SCREEN
+            | TerminalModes::HIDDEN_CURSOR
+            | TerminalModes::MOUSE_CAPTURE;
+        let error = try_new(modes).err().expect("setup must fail");
+
+        assert_eq!(error.kind(), ErrorKind::Other);
+        assert_eq!(
+            operations(),
+            [
+                Operation::EnableRawMode,
+                Operation::EnterAlternateScreen,
+                Operation::HideCursor,
+                Operation::ShowCursor,
+                Operation::LeaveAlternateScreen,
+                Operation::DisableRawMode,
+            ]
+        );
+    }
+
+    #[test]
+    fn restores_attempted_setup_when_setup_panics() {
+        reset([]);
+
+        let modes = TerminalModes::RAW_MODE
+            | TerminalModes::ALTERNATE_SCREEN
+            | TerminalModes::HIDDEN_CURSOR
+            | TerminalModes::MOUSE_CAPTURE;
+        let panic = std::panic::catch_unwind(|| {
+            TerminalSession::try_new_with(panicking_backend, modes, false).ok();
+        });
+
+        assert!(panic.is_err());
+        assert_eq!(
+            operations(),
+            [
+                Operation::EnableRawMode,
+                Operation::EnterAlternateScreen,
+                Operation::HideCursor,
+                Operation::ShowCursor,
+                Operation::LeaveAlternateScreen,
+                Operation::DisableRawMode,
+            ]
+        );
+    }
+
+    #[test]
+    fn continues_restoring_after_an_error_and_retries_failed_steps() {
+        reset([Operation::DisableMouseCapture]);
+
+        let modes = TerminalModes::RAW_MODE
+            | TerminalModes::ALTERNATE_SCREEN
+            | TerminalModes::HIDDEN_CURSOR
+            | TerminalModes::MOUSE_CAPTURE;
+        let mut session = try_new(modes).unwrap();
+        assert_eq!(session.restore().unwrap_err().kind(), ErrorKind::Other);
+        session.restore().unwrap();
+
+        assert_eq!(
+            operations(),
+            [
+                Operation::EnableRawMode,
+                Operation::EnterAlternateScreen,
+                Operation::HideCursor,
+                Operation::EnableMouseCapture,
+                Operation::DisableMouseCapture,
+                Operation::ShowCursor,
+                Operation::LeaveAlternateScreen,
+                Operation::DisableRawMode,
+                Operation::DisableMouseCapture,
+            ]
+        );
+    }
+
+    #[test]
+    fn applies_only_requested_modes() {
+        reset([]);
+
+        let modes = TerminalModes::ALTERNATE_SCREEN | TerminalModes::MOUSE_CAPTURE;
+        let mut session = try_new(modes).unwrap();
+        session.restore().unwrap();
+
+        assert_eq!(
+            operations(),
+            [
+                Operation::EnterAlternateScreen,
+                Operation::EnableMouseCapture,
+                Operation::DisableMouseCapture,
+                Operation::LeaveAlternateScreen,
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_raw_mode_that_was_already_enabled() {
+        reset([]);
+
+        let modes = TerminalModes::RAW_MODE
+            | TerminalModes::ALTERNATE_SCREEN
+            | TerminalModes::HIDDEN_CURSOR
+            | TerminalModes::MOUSE_CAPTURE;
+        let mut session = TerminalSession::try_new_with(mock_backend, modes, true).unwrap();
+        session.restore().unwrap();
+
+        assert_eq!(
+            operations(),
+            [
+                Operation::EnterAlternateScreen,
+                Operation::HideCursor,
+                Operation::EnableMouseCapture,
+                Operation::DisableMouseCapture,
+                Operation::ShowCursor,
+                Operation::LeaveAlternateScreen,
+            ]
+        );
+    }
+}

--- a/tests/readline/Cargo.toml
+++ b/tests/readline/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-promkit = { path = "../../promkit", features = ["runtime", "text"] }
+promkit = { path = "../../promkit", features = ["runtime", "terminal-session", "text"] }
 readline-example = { package = "readline", path = "../../examples/readline" }
 tokio = { workspace = true }
 

--- a/tests/readline/src/readline_fixture.rs
+++ b/tests/readline/src/readline_fixture.rs
@@ -1,13 +1,21 @@
 use promkit::{
     core::crossterm::{cursor, terminal},
-    Prompt,
+    Prompt, TerminalModes, TerminalSession,
 };
 use readline_example::Readline;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     loop {
-        match Readline::default().run().await {
+        let result = {
+            let modes = TerminalModes::RAW_MODE
+                | TerminalModes::HIDDEN_CURSOR
+                | TerminalModes::MOUSE_CAPTURE;
+            let _terminal_session = TerminalSession::try_new(modes)?;
+            Readline::default().run().await
+        };
+
+        match result {
             Ok(cmd) => {
                 // If the prompt is finalized on the last line, print one line-feed
                 // first so the result does not overwrite the prompt line.

--- a/tests/readline/src/titled_readline_fixture.rs
+++ b/tests/readline/src/titled_readline_fixture.rs
@@ -1,4 +1,4 @@
-use promkit::Prompt;
+use promkit::{Prompt, TerminalModes, TerminalSession};
 use readline_example::Readline;
 
 #[tokio::main]
@@ -7,6 +7,9 @@ async fn main() -> anyhow::Result<()> {
 
     let mut prompt = Readline::default();
     prompt.title.text = "Hi!".into();
+    let modes =
+        TerminalModes::RAW_MODE | TerminalModes::HIDDEN_CURSOR | TerminalModes::MOUSE_CAPTURE;
+    let _terminal_session = TerminalSession::try_new(modes)?;
     prompt.run().await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add `TerminalSession` behind the new `terminal-session` feature
- Add explicit `TerminalModes` flags for:
  - raw mode
  - alternate screen
  - hidden cursor
  - mouse capture
- Restore configured terminal modes through `Drop`
- Roll back terminal setup when initialization fails or unwinds
- Move terminal setup and teardown out of `Prompt::run`
- Update examples to explicitly declare and own their terminal modes
- Remove the direct `scopeguard` dependency

## Breaking change

`Prompt::run` no longer configures or restores terminal modes.

Applications using the `runtime` feature must now manage the terminal lifecycle themselves, either with `TerminalSession` or their own implementation.

```rust
let modes = TerminalModes::RAW_MODE
    | TerminalModes::HIDDEN_CURSOR
    | TerminalModes::MOUSE_CAPTURE;

let _terminal_session = TerminalSession::try_new(modes)?;
prompt.run().await?;
```

Full-screen applications can additionally specify `TerminalModes::ALTERNATE_SCREEN`.

## Design

`TerminalSession` records each terminal mode before attempting to enable it. This allows `Drop` to attempt restoration when setup returns an error or unwinds due to a panic.

Restoration attempts every pending operation even if an earlier operation fails. Explicit mode combinations are used instead of aliases so that each application clearly declares the terminal state it owns.

Signal handling is intentionally outside the scope of this change. Restoration through `Drop` applies to normal scope exit, error propagation, and panic unwinding.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features`
- `cargo test -p promkit --no-default-features --features runtime,terminal-session`
- `cargo clippy -p promkit --no-default-features --features runtime,terminal-session --all-targets -- -D warnings`
